### PR TITLE
Allowing multibyte characters

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ v0.5dev (ongoing development)
   - [fixed] Cleanup I2C handling (https://github.com/lcdproc/lcdproc/pull/8)
   - [fixed] Add more patterns to .gitignore (https://github.com/lcdproc/lcdproc/pull/9)
   - [added] New driver for Olimex MOD-LCD1x9
+  - [fixed] Allow multibyte characters (from string widget)
 
 v0.5.7
  - [fixed] Fix using the left key to change the ring and checkbox menu items

--- a/server/render.c
+++ b/server/render.c
@@ -310,9 +310,6 @@ render_string(Widget *w, int left, int top, int right, int bottom, int fy)
 
 	if ((w != NULL) && (w->text != NULL) &&
 	    (w->x > 0) && (w->y > 0) && (w->y > fy) && (w->y <= bottom - top)) {
-		int length;
-		char str[BUFSIZE];
-
 		/*
 		 * FIXME: Could be a bug here? w->x is recalculated (On first
 		 * call only? Is it preserved between calls?) and first
@@ -320,10 +317,7 @@ render_string(Widget *w, int left, int top, int right, int bottom, int fy)
 		 * strings totally off-screen. Is this on purpose? (M. Dolze)
 		 */
 		w->x = min(w->x, right - left);
-		length = min(right - left - w->x + 1, sizeof(str)-1);
-		strncpy(str, w->text, length);
-		str[length] = '\0';
-		drivers_string(w->x + left, w->y + top, str);
+		drivers_string(w->x + left, w->y + top, w->text);
 	}
 	return 0;
 }


### PR DESCRIPTION
Hi,

this PR is a bit more controversial than the earlier ones. It relates to code that has a lot of FIXMEs and whether the patch does the right thing depends on how we want to address the FIXMEs (if anybody ever cares).

Anyway, I think the change doesn't break anything that isn't already broken and allows many simple cases to just work.

In the long run we probably should have a strategy how to deal with character encodings including multibyte. For now this patch impements the "agnostic strategy" - pass anything to the display driver unmodified.
