### PR TITLE
Update machine_OpenBSD.c

### DIFF
--- a/clients/lcdproc/machine_OpenBSD.c
+++ b/clients/lcdproc/machine_OpenBSD.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/sysctl.h>
-#include <sys/dkstat.h>
+#include <sys/sched.h>
 #include <sys/ucred.h>
 #include <sys/mount.h>
 #include <sys/time.h>


### PR DESCRIPTION
Fix make issues on OpenBSD 5.9+

"machine_OpenBSD.c:48:24: error: sys/dkstat.h: No such file or directory"

sys/dkstat.h is no longer part of OpenBSD 5.9
Remaining defines from this file can already be found in sys/sched.h
