### PR TITLE
Add icp_a125 LCD used in QNAP devices

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -434,3 +434,8 @@ flexible :)
 - Shane Spencer (hardwire)
 - Jim McCracken (merlin_jim)
 - Luis Llorente	(luisllo)
+
+- [Sam Bingner](mailto:sam@bingner.com)
+
+	- Updated icp_a106 driver to support icp_a125 used in QNAP devices
+	  and to add button support

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -633,10 +633,19 @@ KeyMatrix_4_4=Escape
 
 
 
-## ICP A106 driver ##
+## ICP Peripheral Comminication Protocol driver ##
+# Supports A125 and A106
+#
+# Short Press Select: Down
+# Long Press Select: Up
+# Short Press Enter: Enter
+# Long Press Enter: Escape
+#
 [icp_a106]
 Device=/dev/ttyS1
 
+# Display dimensions
+Size=20x2
 
 
 ## Code Mercenaries IO-Warrior driver ##

--- a/clients/lcdproc/mode.c
+++ b/clients/lcdproc/mode.c
@@ -174,6 +174,7 @@ credit_screen(int rep, int display, int *flags_ptr)
 		"Dean Harding",
 		"Christian Leuschen",
 		"Jonathan Kyler",
+		"Sam Bingner",
 		NULL
 	};
 	int contr_num = 0;

--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -217,7 +217,7 @@ LCD driven by the GPIO pins of a Raspberry Pi
 140x32 pixel VFD Display of the Intra2net Intranator 2500 appliance
 .TP
 .B icp_a106
-ICP A106 alarm/LCD board in 19" rack cases by ICP
+ICP Peripheral Communication Protocol alarm/LCD board used in QNAP devices and 19" rack cases made by ICP
 .TP
 .B imon
 iMON IR/VFD modules in cases by Soundgraph/Ahanix/Silverstone/Uneed/Accent

--- a/docs/lcdproc-user/drivers/icp_a106.docbook
+++ b/docs/lcdproc-user/drivers/icp_a106.docbook
@@ -2,17 +2,24 @@
 <title>The icp_a106 Driver</title>
 
 <para>
-This section talks about using LCDproc with the ICP A106 alarm/LCD board,
-used in 19" rack cases by ICP.
+This section talks about using LCDproc with the ICP Peripheral Communication 
+Protocol used by A125 and A106 LCD displays
 </para>
 
-<!-- 20x2 characters, serial connection -->
+<!-- 16x2 A125 or 20x2 in A106 characters, serial connection -->
 
 <para>
 Both LCD and alarm functions are accessed via one serial port, using
 separate commands. Unfortunately, the device runs at slow 1200bps and the
 LCD does not allow user-defined characters, so the bargraphs do not look
 very nice.
+
+The A125 does include two buttons marked ENTER and SELECT.
+
+Short press of ENTER: ENTER
+Long press of ENTER: ESC
+Short press of SELECT: DOWN
+Long press of SELECT: UP
 </para>
 
 <!-- ## ICP A106 driver ## -->
@@ -30,6 +37,15 @@ very nice.
   </term>
   <listitem><para>
     Sets the device to use. Defaults to <filename>/dev/lcd</filename>.
+  </para></listitem>
+</varlistentry>
+<varlistentry>
+  <term>
+    <property>Size</property> =
+    <parameter><replaceable>SIZE</replaceable></parameter>
+  </term>
+  <listitem><para>
+    Sets the display resolution to use. Defaults to 20x2
   </para></listitem>
 </varlistentry>
 </variablelist>

--- a/server/drivers/icp_a106.c
+++ b/server/drivers/icp_a106.c
@@ -2,35 +2,34 @@
  * LCDd \c icp_a106 for the ICP A106 alarm/LCD board used in 19 inch rack cases by ICP.
  */
 
-/*
-  This is the LCDproc driver for the ICP A106 alarm/LCD board,
-  used in 19" rack cases by ICP
-
-  Both LCD and alarm functions are accessed via one serial port, using
-  separate commands. Unfortunately, the device runs at slow 1200bps and the
-  LCD does not allow user-defined characters, so the bargraphs do not look
-  very nice.
-
-  Copyright (C) 2002  Michael Schwingen <michael@schwingen.org>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-
-  This driver is mostly based on the HD44780 and the LCDM001 driver.
-  (Hopefully I have NOT forgotten any file I have stolen code from.
-  If so send me an e-mail or add your copyright here!)
-*/
+/* 
+ * This is the LCDproc driver for the ICP A106 alarm/LCD board, used in 19"
+ * rack cases by ICP
+ * 
+ * Both LCD and alarm functions are accessed via one serial port, using
+ * separate commands. Unfortunately, the device runs at slow 1200bps and the
+ * LCD does not allow user-defined characters, so the bargraphs do not look
+ * very nice.
+ * 
+ * Copyright (C) 2002 Michael Schwingen <michael@schwingen.org>
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ * 
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * 
+ * This driver is mostly based on the HD44780 and the LCDM001 driver.
+ * (Hopefully I have NOT forgotten any file I have stolen code from. If so
+ * send me an e-mail or add your copyright here!)
+ */
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -42,7 +41,7 @@
 #include <sys/time.h>
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #include "lcd.h"
@@ -52,11 +51,11 @@
 
 /** private data for the \c icp_a106 driver */
 typedef struct icp_a106_private_data {
-  unsigned char *framebuf;
-  unsigned char *last_framebuf;
-  int width;
-  int height;
-  int fd;
+	unsigned char *framebuf;
+	unsigned char *last_framebuf;
+	int width;
+	int height;
+	int fd;
 } PrivateData;
 
 
@@ -67,304 +66,343 @@ MODULE_EXPORT int supports_multiple = 0;
 MODULE_EXPORT char *symbol_prefix = "icp_a106_";
 
 
-/////////////////////////////////////////////////////////////////
-// Opens com port and sets baud correctly...
-//
+/**
+ * Initialize the driver.  Opens the COM port and sets BAUD rate.
+ * \param drvthis  Pointer to driver structure.
+ * \retval 0       Success.
+ * \retval <0      Error.
+ */
 MODULE_EXPORT int
-icp_a106_init (Driver *drvthis)
+icp_a106_init(Driver *drvthis)
 {
-  char device[200];
-  int speed=B1200;
-  struct termios portset;
+	char device[200];
+	int speed = B1200;
+	struct termios portset;
 
-  PrivateData *p;
+	PrivateData *p;
 
-  debug(RPT_INFO, "ICP_A106: init(%p)", drvthis );
+	debug(RPT_INFO, "ICP_A106: init(%p)", drvthis);
 
-  // Alocate and store private data
-  p = (PrivateData *) calloc(1, sizeof(PrivateData));
-  if (p == NULL)
-    return -1;
-  if (drvthis->store_private_ptr(drvthis, p))
-    return -1;
+	// Alocate and store private data
+	p = (PrivateData *) calloc(1, sizeof(PrivateData));
+	if (p == NULL)
+		return -1;
+	if (drvthis->store_private_ptr(drvthis, p))
+		return -1;
 
-  // initialize PrivateData
-  p->fd = -1;
-  p->width = 20;
-  p->height = 2;
+	// initialize PrivateData
+	p->fd = -1;
+	p->width = 20;
+	p->height = 2;
 
-  // READ CONFIG FILE:
-  // which serial device should be used
-  strncpy(device, drvthis->config_get_string(drvthis->name, "Device", 0, DEFAULT_DEVICE),
-	  sizeof(device));
-  device[sizeof(device)-1] = '\0';
-  report(RPT_INFO, "%s: using Device %s", drvthis->name, device);
+	// READ CONFIG FILE:
+	// which serial device should be used
+	strncpy(device, drvthis->config_get_string(drvthis->name, "Device", 0, DEFAULT_DEVICE),
+		sizeof(device));
+	device[sizeof(device) - 1] = '\0';
+	report(RPT_INFO, "%s: using Device %s", drvthis->name, device);
 
-  p->framebuf = malloc(p->width * p->height);
-  p->last_framebuf = malloc(p->width * p->height);
-  if ((p->framebuf == NULL) || (p->last_framebuf == NULL)) {
-    report(RPT_ERR, "%s: unable to create framebuffer", drvthis->name);
-    return -1;
-  }
-  memset(p->framebuf, ' ', p->width * p->height);
-  memset(p->last_framebuf, ' ', p->width * p->height);
+	p->framebuf = malloc(p->width * p->height);
+	p->last_framebuf = malloc(p->width * p->height);
+	if ((p->framebuf == NULL) || (p->last_framebuf == NULL)) {
+		report(RPT_ERR, "%s: unable to create framebuffer", drvthis->name);
+		return -1;
+	}
+	memset(p->framebuf, ' ', p->width * p->height);
+	memset(p->last_framebuf, ' ', p->width * p->height);
 
-  // Set up io port correctly, and open it...
-  debug(RPT_DEBUG, "%s: opening serial device: %s", __FUNCTION__, device);
-  p->fd = open(device, O_RDWR | O_NOCTTY | O_NDELAY);
-  if (p->fd == -1) {
-    report(RPT_ERR, "%s: init() failed (%s)", drvthis->name, strerror(errno));
-    if (errno == EACCES)
-	report(RPT_ERR, "%s: make sure you have rw access to %s!", drvthis->name, device);
-    return -1;
-  }
-  report(RPT_INFO, "%: opened display on %s", drvthis->name, device);
+	// Set up io port correctly, and open it...
+	debug(RPT_DEBUG, "%s: opening serial device: %s", __FUNCTION__, device);
+	p->fd = open(device, O_RDWR | O_NOCTTY | O_NDELAY);
+	if (p->fd == -1) {
+		report(RPT_ERR, "%s: init() failed (%s)", drvthis->name, strerror(errno));
+		if (errno == EACCES)
+			report(RPT_ERR, "%s: make sure you have rw access to %s!", drvthis->name,
+			       device);
+		return -1;
+	}
+	report(RPT_INFO, "%: opened display on %s", drvthis->name, device);
 
-  tcgetattr(p->fd, &portset);
+	tcgetattr(p->fd, &portset);
 #ifdef HAVE_CFMAKERAW
-  /* The easy way: */
-  cfmakeraw(&portset);
+	/* The easy way: */
+	cfmakeraw(&portset);
 #else
-  /* The hard way: */
-  portset.c_iflag &= ~( IGNBRK | BRKINT | PARMRK | ISTRIP
-			| INLCR | IGNCR | ICRNL | IXON );
-  portset.c_oflag &= ~OPOST;
-  portset.c_lflag &= ~( ECHO | ECHONL | ICANON | ISIG | IEXTEN );
-  portset.c_cflag &= ~( CSIZE | PARENB | CRTSCTS );
-  portset.c_cflag |= CS8 | CREAD | CLOCAL ;
+	/* The hard way: */
+	portset.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
+	portset.c_oflag &= ~OPOST;
+	portset.c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+	portset.c_cflag &= ~(CSIZE | PARENB | CRTSCTS);
+	portset.c_cflag |= CS8 | CREAD | CLOCAL;
 #endif
-  cfsetospeed(&portset, speed);
-  cfsetispeed(&portset, speed);
-  tcsetattr(p->fd, TCSANOW, &portset);
-  tcflush(p->fd, TCIOFLUSH);
+	cfsetospeed(&portset, speed);
+	cfsetispeed(&portset, speed);
+	tcsetattr(p->fd, TCSANOW, &portset);
+	tcflush(p->fd, TCIOFLUSH);
 
-  // stop auto clock display, clear display
-  write(p->fd, "\x4D\x28\x4D\x0D", 4);
+	// stop auto clock display, clear display
+	write(p->fd, "\x4D\x28\x4D\x0D", 4);
 
-  report(RPT_DEBUG, "%s: init() done", drvthis->name);
+	report(RPT_DEBUG, "%s: init() done", drvthis->name);
 
-  return 0;
+	return 0;
 }
 
-/////////////////////////////////////////////////////////////////
-// Clean-up
-//
+/**
+ * Close the driver (do necessary clean-up).
+ * \param drvthis  Pointer to driver structure.
+ */
 MODULE_EXPORT void
-icp_a106_close (Driver *drvthis)
+icp_a106_close(Driver *drvthis)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  if (p != NULL) {
-    if (p->framebuf != NULL)
-      free(p->framebuf);
-    if (p->last_framebuf != NULL)
-      free(p->last_framebuf);
+	if (p != NULL) {
+		if (p->framebuf != NULL)
+			free(p->framebuf);
+		if (p->last_framebuf != NULL)
+			free(p->last_framebuf);
 
-    // clear display, start auto display
-    if (p->fd >= 0) {
-      write(p->fd, "\x4D\x0D\x4D\x29", 4);
-      close(p->fd);
-    }
-    free(p);
-  }
-  drvthis->store_private_ptr(drvthis, NULL);
+		// clear display, start auto display
+		if (p->fd >= 0) {
+			write(p->fd, "\x4D\x0D\x4D\x29", 4);
+			close(p->fd);
+		}
+		free(p);
+	}
+	drvthis->store_private_ptr(drvthis, NULL);
 
-  report(RPT_INFO, "%s: closed", drvthis->name);
+	report(RPT_INFO, "%s: closed", drvthis->name);
 }
 
-/////////////////////////////////////////////////////////////////
-// Returns the display width
-//
+/**
+ * Return the display width in characters.
+ * \param drvthis  Pointer to driver structure.
+ * \return         Number of characters the display is wide.
+ */
 MODULE_EXPORT int
-icp_a106_width (Driver *drvthis)
+icp_a106_width(Driver *drvthis)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  return p->width;
+	return p->width;
 }
 
-/////////////////////////////////////////////////////////////////
-// Returns the display height
-//
+/**
+ * Return the display width in characters.
+ * \param drvthis  Pointer to driver structure.
+ * \return         Number of characters the display is wide.
+ */
 MODULE_EXPORT int
-icp_a106_height (Driver *drvthis)
+icp_a106_height(Driver *drvthis)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  return p->height;
+	return p->height;
 }
 
-/////////////////////////////////////////////////////////////////
-// Clears the LCD screen
-//
+/**
+ * Clear the LCD screen
+ * \param drvthis  Pointer to driver structure.
+ */
 MODULE_EXPORT void
-icp_a106_clear (Driver *drvthis)
+icp_a106_clear(Driver *drvthis)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  memset(p->framebuf, ' ', p->width * p->height);
+	memset(p->framebuf, ' ', p->width * p->height);
 }
 
-//////////////////////////////////////////////////////////////////
-// Flushes all output to the lcd...
-//
+/**
+ * Flush data on screen to the LCD.
+ * \param drvthis  Pointer to driver structure.
+ */
 MODULE_EXPORT void
-icp_a106_flush (Driver *drvthis)
+icp_a106_flush(Driver *drvthis)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
-  /*
-    The ICP A106 is a bit difficult to handle - 1200bps, ho handshake, and
-    the controller is easily overrun and displays garbage when it has too much
-    of work to do. It seems we can handle two full updates per second, so if
-    the last update was less than 0.5 seconds ago, we simply skip this one
-    and update the display the next time.
-  */
-  struct timeval tv, tv2;
-  static struct timeval tv_old; /* time of last update */
-  int line;
-  static char cmd[] = "\x4D\x0c\x00\x14";
+	PrivateData *p = (PrivateData *) drvthis->private_data;
+	/* 
+	 * The ICP A106 is a bit difficult to handle - 1200bps, ho handshake,
+	 * and the controller is easily overrun and displays garbage when it
+	 * has too much of work to do. It seems we can handle two full updates 
+	 * per second, so if the last update was less than 0.5 seconds ago, we 
+	 * simply skip this one and update the display the next time. */
+	struct timeval tv, tv2;
+	static struct timeval tv_old;	/* time of last update */
+	int line;
+	static char cmd[] = "\x4D\x0c\x00\x14";
 
-  gettimeofday(&tv, 0);
-  timersub(&tv, &tv_old, &tv2);
+	gettimeofday(&tv, 0);
+	timersub(&tv, &tv_old, &tv2);
 
-  if ((tv2.tv_sec ==0) && (tv2.tv_usec < 500000)) // less than 0.5s
-    return;
-  tv_old = tv;
+	// Don't allow updates faster than 2fps
+	if ((tv2.tv_sec == 0) && (tv2.tv_usec < 500000))
+		return;
 
-  for (line = 0; line < p->height; line++) {
-    if (memcmp(p->framebuf + line * p->width,
-	       p->last_framebuf + line * p->width, p->width) != 0) {
-      cmd[2] = line;
-      write(p->fd, cmd, 4);
-      write(p->fd, p->framebuf + line * p->width, 20);
-    }
-  }
-  memcpy(p->last_framebuf, p->framebuf, p->width * p->height);
+	tv_old = tv;
+
+	for (line = 0; line < p->height; line++) {
+		if (memcmp(p->framebuf + line * p->width,
+			   p->last_framebuf + line * p->width, p->width) != 0) {
+			cmd[2] = line;
+			write(p->fd, cmd, 4);
+			write(p->fd, p->framebuf + line * p->width, 20);
+		}
+	}
+	memcpy(p->last_framebuf, p->framebuf, p->width * p->height);
 }
 
-/////////////////////////////////////////////////////////////////
-// Prints a character on the lcd display, at position (x,y).  The
-// upper-left is (1,1), and the lower right should be (16,2).
-//
+/**
+ * Print a character on the LCD display at position (x,y).
+ * The upper-left corner is (1,1), the lower-right corner is (p->width, p->height).
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param y        Vertical character position (row).
+ * \param c        Character that gets written.
+ */
 MODULE_EXPORT void
-icp_a106_chr (Driver *drvthis, int x, int y, char ch)
+icp_a106_chr(Driver *drvthis, int x, int y, char ch)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  y--;
-  x--;
-  //debug(RPT_DEBUG, "icp_a106_chr: x=%d, y=%d, chr=%x", x,y,ch);
-  if ((x >= 0) && (x < p->width) && (y >= 0) && (y < p->height))
-    p->framebuf[ y * p->width + x] = ch;
+	y--;
+	x--;
+	// debug(RPT_DEBUG, "icp_a106_chr: x=%d, y=%d, chr=%x", x,y,ch);
+	if ((x >= 0) && (x < p->width) && (y >= 0) && (y < p->height))
+		p->framebuf[y * p->width + x] = ch;
 }
 
-/////////////////////////////////////////////////////////////////
-// Prints a string on the lcd display, at position (x,y).  The
-// upper-left is (1,1), and the lower right should be (16,2).
-//
+/**
+ * Print a string on the LCD display at position (x,y).
+ * The upper-left corner is (1,1), the lower-right corner is (p->width, p->height).
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param y        Vertical character position (row).
+ * \param string   String that gets written.
+ */
 MODULE_EXPORT void
-icp_a106_string (Driver *drvthis, int x, int y, char *s)
+icp_a106_string(Driver *drvthis, int x, int y, char *s)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  x--;  // Convert 1-based coords to 0-based
-  y--;
+	x--;			// Convert 1-based coords to 0-based
+	y--;
 
-  if ((y < 0) || (y >= p->height))
-    return;
+	if ((y < 0) || (y >= p->height))
+		return;
 
-  for ( ; (*s != '\0') && (x < p->width); s++, x++)
-    if (x >= 0)
-      p->framebuf[y * p->width + x] = *s;
+	for (; (*s != '\0') && (x < p->width); s++, x++)
+		if (x >= 0)
+			p->framebuf[y * p->width + x] = *s;
 }
 
 
-/////////////////////////////////////////////////////////////////
-// Draws a vertical bar, from the bottom of the screen up.
-//
+/**
+ * Draw a vertical bar bottom-up.
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column) of the starting point.
+ * \param y        Vertical character position (row) of the starting point.
+ * \param len      Number of characters that the bar is high at 100%
+ * \param promille Current height level of the bar in promille.
+ * \param options  Options (currently unused).
+ */
 MODULE_EXPORT void
-icp_a106_vbar (Driver *drvthis, int x, int y, int len, int promille, int options)
+icp_a106_vbar(Driver *drvthis, int x, int y, int len, int promille, int options)
 {
-  int total_pixels = ((long) 2 * len * LCD_DEFAULT_CELLHEIGHT + 1 ) * promille / 2000;
-  int pos;
-  static char map[] = " __---=#";
+	int total_pixels = ((long) 2 * len * LCD_DEFAULT_CELLHEIGHT + 1) * promille / 2000;
+	int pos;
+	static char map[] = " __---=#";
 
-  for (pos = 0; pos < len; pos ++) {
-    int pixels = total_pixels - LCD_DEFAULT_CELLHEIGHT * pos;
+	for (pos = 0; pos < len; pos++) {
+		int pixels = total_pixels - LCD_DEFAULT_CELLHEIGHT * pos;
 
-    if (pixels >= LCD_DEFAULT_CELLHEIGHT) {
-      /* write a "full" block to the screen... */
-      icp_a106_icon(drvthis, x, y-pos, ICON_BLOCK_FILLED);
-    }
-    else {
-      /* write a partial block... */
-      icp_a106_chr(drvthis, x, y-pos, map[pixels]);
-      break;
-    }
-  }
+		if (pixels >= LCD_DEFAULT_CELLHEIGHT) {
+			/* write a "full" block to the screen... */
+			icp_a106_icon(drvthis, x, y - pos, ICON_BLOCK_FILLED);
+		}
+		else {
+			/* write a partial block... */
+			icp_a106_chr(drvthis, x, y - pos, map[pixels]);
+			break;
+		}
+	}
 }
 
 
-/////////////////////////////////////////////////////////////////
-// Draws a horizontal bar to the right.
-//
+/**
+ * Draw a horizontal bar to the right.
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column) of the starting point.
+ * \param y        Vertical character position (row) of the starting point.
+ * \param len      Number of characters that the bar is long at 100%
+ * \param promille Current length level of the bar in promille.
+ * \param options  Options (currently unused).
+ */
 MODULE_EXPORT void
 icp_a106_hbar(Driver *drvthis, int x, int y, int len, int promille, int options)
 {
-  int total_pixels  = ((long) 2 * len * LCD_DEFAULT_CELLWIDTH + 1 ) * promille / 2000;
-  int pos;
+	int total_pixels = ((long) 2 * len * LCD_DEFAULT_CELLWIDTH + 1) * promille / 2000;
+	int pos;
 
-  for (pos = 0; pos < len; pos ++) {
-    int pixels = total_pixels - LCD_DEFAULT_CELLWIDTH * pos;
+	for (pos = 0; pos < len; pos++) {
+		int pixels = total_pixels - LCD_DEFAULT_CELLWIDTH * pos;
 
-    if (pixels >= LCD_DEFAULT_CELLWIDTH) {
-      /* write a "full" block to the screen... */
-      icp_a106_icon(drvthis, x+pos, y, ICON_BLOCK_FILLED);
-    }
-    else if (pixels > 0) {
-      /* write a partial block... */
-      icp_a106_chr(drvthis, x+pos, y, '|');
-      break;
-    }
-    else {
-      ; /* write nothing (not even a space) */
-    }
-  }
+		if (pixels >= LCD_DEFAULT_CELLWIDTH) {
+			/* write a "full" block to the screen... */
+			icp_a106_icon(drvthis, x + pos, y, ICON_BLOCK_FILLED);
+		}
+		else if (pixels > 0) {
+			/* write a partial block... */
+			icp_a106_chr(drvthis, x + pos, y, '|');
+			break;
+		}
+		else {
+			;	/* write nothing (not even a space) */
+		}
+	}
 }
 
 
-/////////////////////////////////////////////////////////////////
-// Writes a big number.
-//
+/**
+ * Write a big number to the LCD display.
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param num      Character to write (0 - 10 with 10 representing ':')
+ */
 MODULE_EXPORT void
-icp_a106_num (Driver *drvthis, int x, int num)
+icp_a106_num(Driver *drvthis, int x, int num)
 {
-  PrivateData *p = (PrivateData *) drvthis->private_data;
+	PrivateData *p = (PrivateData *) drvthis->private_data;
 
-  if ((num < 0) || (num > 10))
-    return;
+	if ((num < 0) || (num > 10))
+		return;
 
-  icp_a106_chr(drvthis, x, 1 + (p->height - 1) / 2,
-	       (num == 10) ? ':' : (num + '0'));
+	icp_a106_chr(drvthis, x, 1 + (p->height - 1) / 2, (num == 10) ? ':' : (num + '0'));
 }
 
 
-/////////////////////////////////////////////////////////////////
-// Sets character 0 to an icon...
-//
+/**
+ * Place an icon on the screen.
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param y        Vertical character position (row).
+ * \param icon     synbolic value representing the icon.
+ * \retval 0       Icon has been successfully defined/written.
+ * \retval <0      Server core shall define/write the icon.
+ */
 MODULE_EXPORT int
-icp_a106_icon (Driver *drvthis, int x, int y, int icon)
+icp_a106_icon(Driver *drvthis, int x, int y, int icon)
 {
-  switch (icon) {
-    case ICON_BLOCK_FILLED:
-      icp_a106_chr(drvthis, x, y, 255);
-      break;
-    case ICON_HEART_FILLED:
-      break;
-    case ICON_HEART_OPEN:
-      break;
-    default:
-      return -1;
-  }
-  return 0;
+	switch (icon) {
+	case ICON_BLOCK_FILLED:
+		icp_a106_chr(drvthis, x, y, 255);
+		break;
+	case ICON_HEART_FILLED:
+		break;
+	case ICON_HEART_OPEN:
+		break;
+	default:
+		return -1;
+	}
+	return 0;
 }

--- a/server/drivers/icp_a106.h
+++ b/server/drivers/icp_a106.h
@@ -1,51 +1,50 @@
-/*
-  This is the LCDproc driver for the ICP A106 alarm/LCD board,
-  used in 19" rack cases by ICP
-
-  Both LCD and alarm functions are accessed via one serial port, using
-  separate commands. Unfortunately, the device runs at slow 1200bps and the
-  LCD does not allow user-defined characters, so the bargraphs do not look
-  very nice.
-
-  Copyright (C) 2002  Michael Schwingen <michael@schwingen.org>
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
-
-  This driver is mostly based on the HD44780 and the LCDM001 driver.
-  (Hopefully I have NOT forgotten any file I have stolen code from.
-  If so send me an e-mail or add your copyright here!)
-*/
+/* 
+ * This is the LCDproc driver for the ICP A106 alarm/LCD board, used in 19"
+ * rack cases by ICP
+ * 
+ * Both LCD and alarm functions are accessed via one serial port, using
+ * separate commands. Unfortunately, the device runs at slow 1200bps and the
+ * LCD does not allow user-defined characters, so the bargraphs do not look
+ * very nice.
+ * 
+ * Copyright (C) 2002  Michael Schwingen <michael@schwingen.org>
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ * 
+ * This driver is mostly based on the HD44780 and the LCDM001 driver.
+ * (Hopefully I have NOT forgotten any file I have stolen code from.
+ * If so send me an e-mail or add your copyright here!)
+ */
 
 #ifndef ICP_A106_H
 #define ICP_A106_H
 
-MODULE_EXPORT int  icp_a106_init (Driver *drvthis);
-MODULE_EXPORT void icp_a106_close (Driver *drvthis);
-MODULE_EXPORT int  icp_a106_width (Driver *drvthis);
-MODULE_EXPORT int  icp_a106_height (Driver *drvthis);
-MODULE_EXPORT void icp_a106_clear (Driver *drvthis);
-MODULE_EXPORT void icp_a106_flush (Driver *drvthis);
-MODULE_EXPORT void icp_a106_string (Driver *drvthis, int x, int y, char *s);
-MODULE_EXPORT void icp_a106_chr (Driver *drvthis, int x, int y, char ch);
+MODULE_EXPORT int icp_a106_init(Driver *drvthis);
+MODULE_EXPORT void icp_a106_close(Driver *drvthis);
+MODULE_EXPORT int icp_a106_width(Driver *drvthis);
+MODULE_EXPORT int icp_a106_height(Driver *drvthis);
+MODULE_EXPORT void icp_a106_clear(Driver *drvthis);
+MODULE_EXPORT void icp_a106_flush(Driver *drvthis);
+MODULE_EXPORT void icp_a106_string(Driver *drvthis, int x, int y, char *s);
+MODULE_EXPORT void icp_a106_chr(Driver *drvthis, int x, int y, char ch);
 
-MODULE_EXPORT void icp_a106_vbar (Driver *drvthis, int x, int y, int len, int promille, int options);
-MODULE_EXPORT void icp_a106_hbar (Driver *drvthis, int x, int y, int len, int promille, int options);
-MODULE_EXPORT void icp_a106_num (Driver *drvthis, int x, int num);
-MODULE_EXPORT int  icp_a106_icon (Driver *drvthis, int x, int y, int icon);
+MODULE_EXPORT void icp_a106_vbar(Driver *drvthis, int x, int y, int len, int promille, int options);
+MODULE_EXPORT void icp_a106_hbar(Driver *drvthis, int x, int y, int len, int promille, int options);
+MODULE_EXPORT void icp_a106_num(Driver *drvthis, int x, int num);
+MODULE_EXPORT int icp_a106_icon(Driver *drvthis, int x, int y, int icon);
 
 #define DEFAULT_DEVICE "/dev/lcd"
 
 #endif
-

--- a/server/drivers/icp_a106.h
+++ b/server/drivers/icp_a106.h
@@ -44,7 +44,11 @@ MODULE_EXPORT void icp_a106_vbar(Driver *drvthis, int x, int y, int len, int pro
 MODULE_EXPORT void icp_a106_hbar(Driver *drvthis, int x, int y, int len, int promille, int options);
 MODULE_EXPORT void icp_a106_num(Driver *drvthis, int x, int num);
 MODULE_EXPORT int icp_a106_icon(Driver *drvthis, int x, int y, int icon);
+MODULE_EXPORT void icp_a106_backlight(Driver *drvthis, int on);
+MODULE_EXPORT const char *icp_a106_get_key(Driver *drvthis);
 
+#define MAX_BUTTONS 15
 #define DEFAULT_DEVICE "/dev/lcd"
+#define DEFAULT_SIZE "20x2"
 
 #endif


### PR DESCRIPTION
This is a new device because it has input while the a106 does not.  I also have no way to test an a106 so I'm afraid of breaking that driver if I made changes to it.