### PR TITLE
Minor tweaks to help the generation of the configuration GUI based on cme

### DIFF
--- a/LCDd.conf
+++ b/LCDd.conf
@@ -811,7 +811,7 @@ Size=16x2
 [linux_input]
 
 # Select the input device to use [default: /dev/input/event0]
-Device=/dev/input/event0
+# Device=/dev/input/event0
 
 # specify a non-default key map
 #key=1,Escape

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -95,7 +95,7 @@ WaitTime=5
 # it will be a background screen, only visible when no other screens are
 # active. The special value 'blank' is similar to no, but only a blank screen
 # is displayed. [default: on; legal: on, off, blank]
-#ServerScreen=off
+#ServerScreen=no
 
 # Set master backlight setting. If set to 'open' a client may control the
 # backlight for its own screens (only). [default: open; legal: off, open, on]

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -314,7 +314,7 @@ OffBrightness=0
 [EyeboxOne]
 
 # Select the output device to use [default: /dev/ttyS1]
-#Device=/dev/cua01
+# Device=/dev/cua01
 Device=/dev/ttyS1
 
 # Set the display size [default: 20x4]


### PR DESCRIPTION
Hello

Here are some minor changes to `LCDd.conf` that may seem purely cosmetic from your point of view, but they do help the [generation](https://ddumont.wordpress.com/2011/07/03/generate-a-configuration-editor-from-a-config-template-file-with-perl-lcdproc-example/) of [LCDd configuration GUI](https://github.com/dod38fr/config-model/wiki/Managing-Lcdproc-configuration-with-cme).  The rationale of the changes are explained in each commit log.

Could you merge these changes so I don't need to maintain my own version of `LCDd.conf` ?

All the best