### PR TITLE
Update documentation to replace references from CVS to Git

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -27,7 +27,7 @@ In order to compile LCDproc, you'll need the following programs:
   compile it yourself, see http://www.gnu.org/software/make/make.html .
 
 * The GNU autotools, that is automake and autoconf. They are only required
-  if you want to build LCdproc directory from CVS.
+  if you want to build LCdproc directory from Git.
   The GNU autotools are available for all major distributions. If you want
   to compile them yourself, see
   http://www.gnu.org/software/autoconf/ and
@@ -104,8 +104,8 @@ different types of displays are now supported.
 
 -- BUILDING LCDPROC -------------------------------------------------
 
---- Preparing a CVS distro ---
-If you retrieved these files from the CVS, you will first need to run:
+--- Preparing a Git distro ---
+If you retrieved these files from the Git, you will first need to run:
     sh ./autogen.sh
 
 --- Configuration ---

--- a/docs/lcdproc-dev/introduction.docbook
+++ b/docs/lcdproc-dev/introduction.docbook
@@ -16,9 +16,9 @@ See <ulink url="http://lcdproc.org/mail.php3">http://lcdproc.org/mail.php3</ulin
 for details on how to subscribe to the list.
 </para>
 <para>
-Therefore you might want to have a look at <ulink url="http://lcdproc.sourceforge.net/docs/"></ulink>,
+Therefore you might want to have a look at <ulink url="https://github.com/lcdproc/lcdproc/tree/master/docs"></ulink>,
 to get the latest version of this document, unless you want to generate it yourself from the
-docbook files in the CVS).
+docbook files in GIT).
 </para></note>
 
 <para>

--- a/docs/lcdproc-dev/programming.docbook
+++ b/docs/lcdproc-dev/programming.docbook
@@ -9,25 +9,25 @@ the most current source code available. You can get it several ways:</para>
 
 <orderedlist>
   <listitem>
-    <para>Download yesterday's CVS version of as a tarball (preferred).</para>
+    <para>Download GIT version of as a tarball (preferred).</para>
   </listitem>
   <listitem>
-    <para>Download the latest version from CVS.</para>
+    <para>Download the latest version from GIT.</para>
   </listitem>
   <listitem>
-    <para>Download the last stable release from Sourceforge. (This is not
+    <para>Download the last stable release from Github. (This is not
     recommended as stable release may be months behind the current version.)
     </para>
   </listitem>
 </orderedlist>
 
 <sect2 id="downloadtar">
-<title>Download Yesterday's CVS Version of LCDproc as a Tarball</title>
+<title>Download GIT Version of LCDproc as a Tarball</title>
 
 <para>
-There are nightly distributions of the CVS branches of LCDproc. You can
-download them from <ulink url="http://lcdproc.sourceforge.net/nightly/"></ulink>.
-For development we recommended to use the 'current' branch.
+The source is available as tarball. You can
+download them from <ulink url="https://github.com/lcdproc/lcdproc/archive/master.tar.gz"></ulink>.
+For development we recommended to use the 'master' branch.
 </para>
 
 <para>
@@ -35,48 +35,31 @@ To extract the files run
 </para>
 
 <screen>
-<prompt>$</prompt> <userinput>tar xvfz lcdproc-CVS-current.tar.gz</userinput>
+<prompt>$</prompt> <userinput>tar xvfz lcdproc-master.tar.gz</userinput>
 </screen>
 
 </sect2>
 
-<sect2 id="downloadcvs">
-<title>Download The Latest Version of LCDproc from CVS</title>
+<sect2 id="downloadgit">
+<title>Download The Latest Version of LCDproc from GitHub</title>
 
 <para>
-Of course you can download the latest stuff from CVS via anonymous login.
-For more information on how to use CVS see
-<ulink url="http://sourceforge.net/scm/?type=cvs&amp;group_id=119">About CVS</ulink>
-on Sourceforge.
-</para>
-
-<para>
-Login to CVS:
+Of course you can download the latest stuff from GitHub.
+For more information on how to use GitHub see
+<ulink url="https://guides.github.com/"></ulink>.
 </para>
 
 <screen>
-<prompt>$</prompt> <userinput>cvs -d:pserver:anonymous@lcdproc.cvs.sourceforge.net:/cvsroot/lcdproc login</userinput>
-</screen>
-
-<para>
-(Hit enter when prompted for a password.)
-</para>
-
-<para>
-Get the files from CVS:
-</para>
-
-<screen>
-<prompt>$</prompt> <userinput>cvs -d:pserver:anonymous@lcdproc.cvs.sourceforge.net:/cvsroot/lcdproc checkout -P lcdproc</userinput>
+<prompt>$</prompt> <userinput>git clone https://github.com/lcdproc/lcdproc.git</userinput>
 </screen>
 
 <para>
 Once you've done that and want to update the downloaded files to the latest stuff
-you can use the "update" command of CVS (make sure to be in the lcdproc directory!):
+you can use the "pull" command of git (make sure to be in the lcdproc directory!):
 </para>
 
 <screen>
-<prompt>$</prompt> <userinput>cvs update -d</userinput>
+<prompt>$</prompt> <userinput>git pull</userinput>
 </screen>
 
 <para>
@@ -444,40 +427,9 @@ default:
 <title>Submitting code</title>
 
 <para>When you have finished modifying the code you may decide to submit it to
-the LCDproc project. You usually do this by submitting a patch for review to the
-mailing list.</para>
-
-<para>To create a patch you need the unmodified files and the files containing
-your modifications. Usually you do this by storing an unmodified copy of the
-sources in one directory and another copy with your modifications in another
-one. You then run <command>diff</command> like this:</para>
-
-<para><command>diff</command><option>-urN</option>
-<option>-X <replaceable>unmodified-dir</replaceable>/diff_ignore</option>
-<option><replaceable>unmodified-dir</replaceable></option>
-<option><replaceable>your-source-dir</replaceable></option>
-&gt; <replaceable>mymodifications.patch</replaceable></para>
-
-<important>
-<para>Please use unified diff format (<option>-u</option> option) only!</para>
-<para>When running <command>diff</command> using <option>-X diff_ignore</option>
-is strongly recommended. The file <filename>diff_ignore</filename> contains an
-exclusion list which makes <command>cvs</command> ignore all generated files
-(Makefiles, log files, object files, etc.)</para>
-</important>
-
-<para>If you have modified files in a source tree you checked out from CVS
-you can also run <command>cvs diff</command> from the working directory:</para>
-
-<para><command>cvs diff</command><option>-u</option>
-&gt; <replaceable>mymodifications.patch</replaceable></para>
-
-<note>
-<para>Some versions of <command>cvs diff</command> will not handle new files
-because these are unknown to the repository. There are ways to make cvs believe
-the files existed previously (fake add) but this is not recommended. You will
-need to submit new files 'as-is' in this case.</para>
-</note>
+the LCDproc project as a pull request.
+<ulink url="https://help.github.com/articles/about-pull-requests/">Read the
+documentation</ulink> to learn how to make one.</para>
 
 </sect1>
 

--- a/docs/lcdproc-user/how-to-obtain.docbook
+++ b/docs/lcdproc-user/how-to-obtain.docbook
@@ -25,8 +25,8 @@ around on the internet:
   <term>Older releases</term>
   <listitem>
     <para>
-    Older releases of LCDproc can be found on the Sourceforge project page at
-    <ulink url="http://sourceforge.net/projects/lcdproc/files/lcdproc/"></ulink>.
+    Older releases of LCDproc can be found on the GitHub project page at
+    <ulink url="https://github.com/lcdproc/lcdproc"></ulink>.
     </para>
   </listitem>
 </varlistentry>
@@ -36,12 +36,11 @@ around on the internet:
 </sect1>
 
 <sect1 id="tar">
-<title>Download CVS Version of LCDproc as a Tarball</title>
+<title>Download Git Version of LCDproc as a Tarball</title>
 
 <para>
 The snapshot of the current source code repository may be downloaded from the
-web. Goto <ulink url="http://lcdproc.cvs.sourceforge.net/viewvc/lcdproc/"></ulink>
-and click on "Download GNU tarball".
+web. Goto <ulink url="https://github.com/lcdproc/lcdproc/archive/master.tar.gz"></ulink>.
 </para>
 
 <para>
@@ -54,47 +53,27 @@ To extract the files run
 
 </sect1>
 
-<sect1 id="cvs">
-<title>Download The Latest Version of LCDproc from CVS</title>
+<sect1 id="git">
+<title>Download The Latest Version of LCDproc from GitHub</title>
 
 <para>
-Of course you can download the latest stuff from CVS via anonymous login.
-</para>
-
-<para>
-Login to CVS:
-</para>
-
-<screen>
-<prompt>$</prompt> <userinput>cvs -d:pserver:anonymous@lcdproc.cvs.sourceforge.net:/cvsroot/lcdproc login</userinput>
-</screen>
-
-<para>
-(Hit enter when prompted for a password.)
-</para>
-
-<para>
-Get the files from CVS:
+Of course you can download the latest stuff from GitHub.
+For more information on how to use GitHub see
+<ulink url="https://guides.github.com/"></ulink>.
 </para>
 
 <screen>
-<prompt>$</prompt> <userinput>cvs -d:pserver:anonymous@lcdproc.cvs.sourceforge.net:/cvsroot/lcdproc checkout -r stable-0-5-x lcdproc</userinput>
+<prompt>$</prompt> <userinput>git clone https://github.com/lcdproc/lcdproc.git</userinput>
 </screen>
 
 <para>
 Once you've done that and want to update the downloaded files to the latest stuff
-you can use the "update" command of CVS (Make sure to be in the lcdproc directory.):
+you can use the "pull" command of git (make sure to be in the lcdproc directory!):
 </para>
 
 <screen>
-<prompt>$</prompt> <userinput>cvs update -d</userinput>
+<prompt>$</prompt> <userinput>git pull</userinput>
 </screen>
-
-<para>
-Now that once you have downloaded the files you can prepare them for
-compiling, but first you should (you don't have to) copy them to another
-place on your machine.
-</para>
 
 </sect1>
 

--- a/docs/lcdproc-user/installation.docbook
+++ b/docs/lcdproc-user/installation.docbook
@@ -17,7 +17,7 @@ If you have installed the Debian package with <application>apt-get</application>
 </note>
 
 <para>
-If you're building this version from CVS, you'll need
+If you're building this version from Git, you'll need
 <application>autoconf</application>, <application>automake</application>,
 <application>aclocal</application> and <application>autoheader</application> installed.
 </para>

--- a/docs/lcdproc-user/introduction.docbook
+++ b/docs/lcdproc-user/introduction.docbook
@@ -20,7 +20,7 @@ for details on how to subscribe to the list.
 <para>
 Therefore you might want to have a look at <ulink url="http://lcdproc.sourceforge.net/docs/"></ulink>,
 to get the latest version of this document (unless you want to generate it yourself from the
-docbook files in the CVS).
+docbook files in the Git).
 </para></note>
 
 <para>


### PR DESCRIPTION
Here is an update of the documentation to replace references from CVS to Git.

As I don't know how you want to update the release process, the file `docs/lcdproc-dev/releasing.docbook` has not been modified.