### PR TITLE
NoritakeVFD: Fix # Of Custom Characters

### DIFF
--- a/server/drivers/NoritakeVFD.c
+++ b/server/drivers/NoritakeVFD.c
@@ -66,7 +66,7 @@
 
 
 /* Constants for userdefchar_mode */
-#define NUM_CCs		2 /* max. number of custom characters */
+#define NUM_CCs		8 /* max. number of custom characters */
 
 /** private data for the \c NoritakeVFD driver */
 typedef struct NoritakeVFD_private_data {


### PR DESCRIPTION
The display the driver was tested with, CU40026SCPB-T20A, supports 8 custom characters according to datasheet. Page 2/4 "Escape Commands", "8 User Defineable Characters (UDC)".
I tested the patch with with the CU20045SCPB-T31A which also supports at least 8 custom characters.
As I'm not sure about external links, please search for PDFs of the datasheets if required. They are easy to find.
So big numbers can be displayed in nicer way, see adv_bignum.c.