### PR TITLE
server/drivers: Make report() available globally

### DIFF
--- a/docs/lcdproc-dev/driver-api.docbook
+++ b/docs/lcdproc-dev/driver-api.docbook
@@ -190,10 +190,6 @@ typedef struct lcd_logical_driver {
 	int config_has_section	(const char *sectionname);
 	int config_has_key	(const char *sectionname, const char *keyname);
 
-	// error reporting function
-	// - see drivers/report.h for details
-	void (*report)		( const int level, const char *format, .../*args*/ );
-
 	// Display properties functions (for drivers that adapt to other loaded drivers)
 	// - the return the size of another already loaded driver
 	// - if no driver is loaded yet, the return values will be 0

--- a/server/driver.c
+++ b/server/driver.c
@@ -275,9 +275,6 @@ driver_bind_module(Driver *driver)
 	driver->config_has_section	= config_has_section;
 	driver->config_has_key		= config_has_key;
 
-	/* Reporting */
-	driver->report			= report;
-
 	/* Driver private data */
 	driver->store_private_ptr	= driver_store_private_ptr;
 

--- a/server/drivers/lcd.h
+++ b/server/drivers/lcd.h
@@ -206,10 +206,6 @@ typedef struct lcd_logical_driver {
 	int (*config_has_section)	(const char *sectionname);
 	int (*config_has_key)		(const char *sectionname, const char *keyname);
 
-	/* Reporting function */
-	/* Easily usable by including drivers/report.h */
-	void (*report)			(const int level, const char *format, .../*args*/ );
-
 	/* Display properties functions (for drivers that adapt to other loaded drivers) */
 	int (*request_display_width) ();
 	int (*request_display_height) ();

--- a/server/drivers/report.h
+++ b/server/drivers/report.h
@@ -22,8 +22,7 @@
 #define RPT_INFO 4
 #define RPT_DEBUG 5
 
-#define report drvthis->report
-// This assumes drvthis is locally defined... Anyone has a better idea ?
+extern void report(const int level, const char *format, .../*args*/ );
 
 static inline void dont_report( const int level, const char *format, .../*args*/ )
 {} // The idea is that this gets optimized out


### PR DESCRIPTION
This PR really simplifies the API a lot. If this works, maybe we should do the same with the other function pointers passed via driver data as well. However the report() function is the one that was really annoying.

Can anybody think of a situation where this might break? Can anybody test this with other compilers then gcc or on an other OS then linux? (OS shouldn't matter I think.)

Is somebody unhappy, if I merge this before the release happens?