### PR TITLE
lcdexec.1: Fix typo in example

### DIFF
--- a/docs/lcdexec.1
+++ b/docs/lcdexec.1
@@ -190,7 +190,7 @@ DisplayName="Reboot in 5 minutes"
 Exec="shutdown \-r +5"
 Feedback=yes
 
-[CanclShutdown]
+[CancelShutdown]
 DisplayName="Cancel shutdown/reboot"
 Exec="shutdown \-c"
 Feedback=yes


### PR DESCRIPTION
Credits goes here: https://bugs.launchpad.net/ubuntu/+source/lcdproc/+bug/1351304