### PR TITLE
Fix typos in driver and man page

### DIFF
--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -507,7 +507,7 @@ A graphic icon.
 A scrolling text display, scrolling either horizontally or vertically.
 .TP
 .B frame
-A \fIcontainer\fR to contain other widgets, permitting them to be refered to
+A \fIcontainer\fR to contain other widgets, permitting them to be referred to
 as a single unit.  A widget is put inside a frame by using the \-in \fI#id\fR
 parameter, where \fI#id\fR refers to the id of the frame.
 .TP

--- a/server/drivers/MD8800.c
+++ b/server/drivers/MD8800.c
@@ -633,7 +633,7 @@ MD8800_output (Driver *drvthis, int on)
 		return;
 	p->last_command = on;
 
-	report(RPT_ERR, "commmand send is: %i", on);
+	report(RPT_ERR, "command send is: %i", on);
 	switch (on) {
 	// +0 -> off
 		case 1: // 'hdd'


### PR DESCRIPTION
Hello

This PR fixes 2 typos found by lintian while building a package for Debian.

All the best
