### PR TITLE
Raspberry fixes

### DIFF
--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -293,13 +293,6 @@ static void
 send_nibble(PrivateData *p, unsigned char ch, unsigned char displayID)
 {
 	if (gpio_map != NULL) {
-		/* Clear data lines ready for nibbles */
-		SET_GPIO(p->rpi_gpio->d7, 0);
-		SET_GPIO(p->rpi_gpio->d6, 0);
-		SET_GPIO(p->rpi_gpio->d5, 0);
-		SET_GPIO(p->rpi_gpio->d4, 0);
-		p->hd44780_functions->uPause(p, 50);
-
 		SET_GPIO(p->rpi_gpio->d7, ch & 0x08);
 		SET_GPIO(p->rpi_gpio->d6, ch & 0x04);
 		SET_GPIO(p->rpi_gpio->d5, ch & 0x02);

--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -157,6 +157,7 @@ check_board_rev(Driver *drvthis)
 	while (!feof(fp)) {
 		fgets(buf, sizeof(buf), fp);
 		sscanf(buf, "Hardware	: %7s", hw);
+		hw[7] = '\0';
 		sscanf(buf, "Revision	: %x", &rev);
 	}
 	fclose(fp);

--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -442,12 +442,14 @@ hd_init_rpi(Driver *drvthis)
 	}
 
 	/* Setup the lcd in 4 bit mode: Send (FUNCSET | IF_8BIT) three times
-	 * followed by (FUNCSET | IF_4BIT) using four nibbles. Timing is not
-	 * exactly what is required by HD44780. */
-	p->hd44780_functions->senddata(p, 0, RS_INSTR, 0x33);
+	 * followed by (FUNCSET | IF_4BIT) using four nibbles. */
+	SET_GPIO(p->rpi_gpio->rs, 0);
+	send_nibble(p, (FUNCSET | IF_8BIT) >> 4, 0);
 	p->hd44780_functions->uPause(p, 4100);
-	p->hd44780_functions->senddata(p, 0, RS_INSTR, 0x32 );
+	send_nibble(p, (FUNCSET | IF_8BIT) >> 4, 0);
 	p->hd44780_functions->uPause(p, 150);
+	send_nibble(p, (FUNCSET | IF_8BIT) >> 4, 0);
+	send_nibble(p, (FUNCSET | IF_4BIT) >> 4, 0);
 
 	common_init(p, IF_4BIT);
 

--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -247,11 +247,11 @@ setup_gpio(Driver *drvthis, int gpio)
 {
 	volatile int i;
 
-#define GPPUP    gpio_map + 37
+#define GPPUD    gpio_map + 37
 #define GPPUDCLK gpio_map + 38
 
 	/* Disable pull-up/down */
-	*(GPPUP) &= ~3;
+	*(GPPUD) &= ~3;
 
 	/*
 	 * After writing to the GPPUD register, need to wait 150 cycles as per
@@ -270,7 +270,7 @@ setup_gpio(Driver *drvthis, int gpio)
 	while (--i);
 
 	/* Write again to GPPUD and disable clock */
-	*(GPPUP) &= ~3;
+	*(GPPUD) &= ~3;
 	*(GPPUDCLK + (gpio / 32)) = 0;
 
 	/*
@@ -431,12 +431,8 @@ lcdrpi_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char f
 		return;
 	}
 
-	if (flags == RS_INSTR) {
-		SET_GPIO(p->rpi_gpio->rs, 0);
-	}
-	else {			/* flags == RS_DATA */
-		SET_GPIO(p->rpi_gpio->rs, 1);
-	}
+	SET_GPIO(p->rpi_gpio->rs, (flags == RS_INSTR) ? 0 : 1);
+
 	/* Clear data lines ready for nibbles */
 	SET_GPIO(p->rpi_gpio->d7, 0);
 	SET_GPIO(p->rpi_gpio->d6, 0);

--- a/server/drivers/hd44780-rpi.h
+++ b/server/drivers/hd44780-rpi.h
@@ -20,8 +20,8 @@ struct rpi_gpio_map {
 };
 
 /** Peripheral base address of the BCM2835 */
-#define BCM2835_PERI_BASE_PI12       0x20000000
-#define BCM2835_PERI_BASE_PI3        0x3F000000
+#define BCM2835_PERI_BASE_OLD        0x20000000
+#define BCM2835_PERI_BASE_NEW        0x3F000000
 /** GPIO register start address offset from PERI_BASE */
 #define GPIO_BASE_OFFSET               0x200000
 /** Length of register space */


### PR DESCRIPTION
The attached patch series contains fixes for hd44780's ConnectionType raspberrypi.
* it detects Rapsberry all raspberry versions correctly and in a more secure manner
   - tested with Pi B, Pi2 as well as Pi3 and one as well as two-controller displays
  - the previous implementation failed even detecting my Pi2
* it saves code by introducing a function send_nibble() following hd44780-gpio.c
* it remove unnecessary 0-ing of GPIO pins before outputting the real values

Everything tested with Pi B, Pi2, P3 as well as single-controller (16x2, 20x4) and multi-controller-displays (27x4)