### PR TITLE
musl: add headers for clean compilation with MUSL libraries

### DIFF
--- a/clients/lcdproc/batt.c
+++ b/clients/lcdproc/batt.c
@@ -15,6 +15,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/utsname.h>
+#include <time.h>
 
 #include "shared/sockets.h"
 

--- a/clients/lcdproc/cpu.c
+++ b/clients/lcdproc/cpu.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <limits.h>
 #include <errno.h>
+#include <time.h>
 
 #include "shared/sockets.h"
 

--- a/clients/lcdproc/cpu_smp.c
+++ b/clients/lcdproc/cpu_smp.c
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <time.h>
 
 #include "shared/sockets.h"
 

--- a/clients/lcdproc/load.c
+++ b/clients/lcdproc/load.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <time.h>
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"

--- a/clients/lcdproc/mem.c
+++ b/clients/lcdproc/mem.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <time.h>
 
 #include "shared/sockets.h"
 #include "shared/LL.h"

--- a/clients/lcdproc/mode.c
+++ b/clients/lcdproc/mode.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <sys/utsname.h>
 #include <string.h>
+#include <time.h>
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"

--- a/server/drivers/rawserial.c
+++ b/server/drivers/rawserial.c
@@ -37,6 +37,7 @@
 #include <termios.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/types.h>
 
 #include <errno.h>
 #include <limits.h>


### PR DESCRIPTION
Without this patch, compilation under MUSL 1.1.16 generates a lot of warnings about the wrong versions of headers being included.