### PR TITLE
t6963: move inline declarations into same module as function

### DIFF
--- a/server/drivers/t6963_low.c
+++ b/server/drivers/t6963_low.c
@@ -43,6 +43,9 @@
 #define T_DATA	0x00		/* ~INIT didn't work here */
 
 
+inline void
+t6963_low_send(T6963_port *p, u8 type, u8 byte);
+
 /**
  * Acquires access to parallel port and initializes timing. The parallel port
  * must be an I/O-address between 0x200 and 0x400.

--- a/server/drivers/t6963_low.h
+++ b/server/drivers/t6963_low.h
@@ -107,6 +107,5 @@ void t6963_low_command(T6963_port *p, u8 byte);
 void t6963_low_command_byte(T6963_port *p, u8 cmd, u8 byte);
 void t6963_low_command_word(T6963_port *p, u8 cmd, u16 word);
 int t6963_low_dsp_ready(T6963_port *p, u8 sta);
-inline void t6963_low_send(T6963_port *p, u8 type, u8 byte);
 
 #endif


### PR DESCRIPTION
Static inlines need to be declared in the same module as they're defined.