### PR TITLE
sdeclcd: don't rely on STRB bit being 1/0 when manipulating backlighting

### DIFF
--- a/server/drivers/sdeclcd.c
+++ b/server/drivers/sdeclcd.c
@@ -51,8 +51,9 @@
  * mapping between the parallel port Control register and the
  * LCD control lines, as follows: (see lpt-port.h for defs)
  */
-#define SDEC_BACKLIGHT	STRB	/* Strobe, bit 0			*/
-#define SDEC_ENABLE	LF	/* Linefeed, bit			*/
+#define SDEC_BACKLIGHT_ON STRB	/* Strobe, bit 0			*/
+#define SDEC_BACKLIGHT_OFF 0
+#define SDEC_ENABLE	LF	/* Linefeed, bit 1			*/
 #define SDEC_CONTRAST	INIT	/* Init, bit 2 <--FIXME, Untested	*/
 #define SDEC_REG_SEL	SEL	/* Select Printer, bit 3		*/
 
@@ -178,10 +179,12 @@ static inline void
 _sdec_control_wait(unsigned char register_select, unsigned char backlight,
 		   unsigned char data, int usec)
 {
-	port_out(LPT_CONTROL, (register_select | backlight | SDEC_ENABLE) ^ LPT_CTRL_MASK);
+	unsigned char backlight_bit = (backlight ? SDEC_BACKLIGHT_ON : SDEC_BACKLIGHT_OFF);
+
+	port_out(LPT_CONTROL, (register_select | backlight_bit | SDEC_ENABLE) ^ LPT_CTRL_MASK);
 	port_out(LPT_DEFAULT, data);
 	timing_uPause(SDEC_HOLD_ENABLE);
-	port_out(LPT_CONTROL, (register_select | backlight) ^ LPT_CTRL_MASK);
+	port_out(LPT_CONTROL, (register_select | backlight_bit) ^ LPT_CTRL_MASK);
 	timing_uPause(usec);
 }
 


### PR DESCRIPTION
This code works on the lucky coincidence that backlighting is controlled
by the `STRB` bit whose value is 1, and that this function is called with
a 0 or 1 value to reset/set backlighting.

If I called `sdec_write(..., 99)` that would also be a valid way of
turning on the backlight, since that argument is ultimately zero or
non-zero in how it's interpreted.  But that would then mask in the
wrong value into the control register.

So, test backlight for being non-zero, but then assign the right bit
(which happens to be 1 or 0) into the variable we then combine to
generate the correct register value.

If we were running on different hardware were the 2 bit controlled
the backlighting, obvious this wouldn't work... so it's a lucky
coincidence that it does.