### PR TITLE
Hd44780 ezio

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -452,3 +452,9 @@ flexible :)
 
   - Driver for the Futaba TOSD-5711BB VFDisplay on Elonex Artisan/Scaleo/FIC
     Spectra Media Cenre PCs amoungst others
+
+- [Francois Mertz](mailto:fireboxled@gmail.com)
+
+  - Parallel Port LCD driver for the Watchguard/Lanner firewall appliances (sdeclcd)
+
+  - Supplemented HD44780 serial driver to support Portwell EZIO-100 and EZIO-300 LCDs found in Portwell, Caswell and Check Point firewall appliances

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@ v0.5dev (ongoing development)
   - [fixed] Make display update interval selectable from LCDd.conf
   - [fixed] Move --enable-permissive-menu-goto from configure to LCDd.conf
   - [fixed] Segfault in LL_Find() on empty list
+  - [fixed] Add C99 (https://github.com/lcdproc/lcdproc/issues/81)
+  - [added] Add Portwell EZIO-100 and EZIO-300 support to serial HD44780 driver
 
 v0.5.8
   - [added] Add driver for the Futaba TOSD-5711BB VFDisplay on Elonex Artisan/Scaleo/FIC Spectra Media Centre PCs

--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -161,6 +161,9 @@ LCD driven by a PIC16C54-based piggy-back board, connected to a serial port
 .B los-panel
 LCD driven by an Atmel AVR based board, connected to a serial port
 .TP
+.B ezio
+Portwell EZIO-100 and EZIO-300 LCD connected to a serial port (http://drivers.portwell.com/CA_Manual/EZIO/)
+.TP
 .B vdr-lcd
 ???, connected to a serial port
 .TP

--- a/docs/lcdproc-dev/programming.docbook
+++ b/docs/lcdproc-dev/programming.docbook
@@ -103,7 +103,8 @@ should look like.
   <listitem>
     <para>
     <emphasis>Language: </emphasis>The programming language used for LCDd
-    (server core), drivers and the lcdproc client is <literal>C</literal>.
+    (server core), drivers and the lcdproc client is Standard <literal>C</literal>,
+    currently <literal>C99</literal>.
     No other programming language will be accepted.
     </para>
   </listitem>

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -102,6 +102,10 @@ of connection (parallel port, serial port, USB, I2C, SPI or others).
         <entry><literal><link linkend="hd44780-vdr-wakeup">vdr-wakeup</link></literal></entry>
         <entry>VDR-Wakeup module "vdr-wakeup"</entry>
       </row>
+      <row>
+        <entry><literal><link linkend="hd44780-ezio">ezio</link></literal></entry>
+        <entry>EZIO-100 and EZIO-300 by Portwell</entry>
+      </row>
       <!-- USB -->
       <row>
         <entry spanname="fullwidth">USB connection types:</entry>
@@ -2167,6 +2171,28 @@ See <ulink url="http://www.jepsennet.de/vdr/"></ulink>
 
 </sect3>
 
+<sect3 id="hd44780-ezio">
+<title>EZIO-100 and EZIO-300 by Portwell</title>
+
+<para>
+Portwell EZIO-100 and EZIO-300 are 20x2 HD44780-compatible devices featuring
+a serial port interface to the host on "COM2", and a 4-key keypad. These devices
+are typically found in firewall appliances by Portwell, Caswell, Check Point and others.
+</para>
+
+<para>
+The backlight is always on. The serial port is operating at 2400 bps (2400-N-8-1),
+which the driver defaults to with this connection type. The keypad keys map to the
+default KeyMatrix_4_x settings in the [HD44780] section of LCDd.conf.
+</para>
+<para>
+See <ulink url="http://drivers.portwell.com/CA_Manual/EZIO/EZIO-FINAL.PDF"></ulink> for the EZIO-100 technical document.
+See <ulink url="http://drivers.portwell.com/CA_Manual/EZIO/EZIO-300.pdf"></ulink> for the EZIO-300 technical document.
+</para>
+
+</sect3>
+
+
 <sect3 id="hd44780-pertelian">
 <title>Pertelian X2040 "pertelian"</title>
 
@@ -3474,7 +3500,8 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
       <parameter><literal>pifacecad</literal></parameter> |
       <parameter><literal>ethlcd</literal></parameter> |
       <parameter><literal>raspberrypi</literal></parameter> |
-      <parameter><literal>gpio</literal></parameter>
+      <parameter><literal>gpio</literal></parameter> |
+      <parameter><literal>ezio</literal></parameter>
     }
   </term>
   <listitem>

--- a/server/drivers/hd44780-drivers.h
+++ b/server/drivers/hd44780-drivers.h
@@ -73,6 +73,7 @@ static const ConnectionMapping connectionMapping[] = {
 	{ "vdr-lcd",       HD44780_CT_VDR_LCD,       IF_TYPE_SERIAL,  hd_init_serial    },
 	{ "vdr-wakeup",    HD44780_CT_VDR_WAKEUP,    IF_TYPE_SERIAL,  hd_init_serial    },
 	{ "pertelian",     HD44780_CT_PERTELIAN,     IF_TYPE_SERIAL,  hd_init_serial    },
+	{ "ezio",          HD44780_CT_EZIO,          IF_TYPE_SERIAL,  hd_init_serial    },
 	/* USB connection types */
 	{ "lis2",          HD44780_CT_LIS2,          IF_TYPE_USB,     hd_init_lis2      },
 	{ "mplay",         HD44780_CT_MPLAY,         IF_TYPE_USB,     hd_init_lis2      },

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -61,6 +61,7 @@
 #define HD44780_CT_PIFACECAD		25
 #define HD44780_CT_LCM162		26
 #define HD44780_CT_GPIO			27
+#define HD44780_CT_EZIO			28
 /**@}*/
 
 /** \name Symbolic names for interface types

--- a/server/drivers/hd44780-serial.c
+++ b/server/drivers/hd44780-serial.c
@@ -6,7 +6,7 @@
  * and are connected to a serial port using some microcontroller. It supports
  * protocols using escape sequences to trigger commands, backlight or keys.
  *
- * Currently supported are: \c picanlcd, \c lcdserializer, \c los-panel,
+ * Currently supported are: \c ezio, \c picanlcd, \c lcdserializer, \c los-panel,
  * \c vdr-lcd, \c vdr-wakeup, and \c pertelian.
  */
 
@@ -20,6 +20,7 @@
  *                1999-2000, Benjamin Tse <blt@Comports.com>
  *                2001, Rene Wagner
  *                2001-2002, Joris Robijn <joris@robijn.net>
+ *                2017, Francois Mertz <fireboxled@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -49,6 +50,7 @@
 #include <fcntl.h>
 #include <termios.h>
 #include <errno.h>
+#include <poll.h>
 
 #include "lcd.h"
 #include "hd44780-low.h"
@@ -169,7 +171,7 @@ hd_init_serial(Driver *drvthis)
 
 	/* Get interface type */
 	p->serial_type = 0;
-	for (i = 0; serial_interfaces[i].connectiontype != HD44780_CT_UNKNOWN; i++) {
+	for (i = 0; i < sizeof(serial_interfaces); i++) {
 		if (p->connectiontype == serial_interfaces[i].connectiontype) {
 			p->serial_type = i;
 			break;
@@ -244,6 +246,13 @@ hd_init_serial(Driver *drvthis)
 	p->hd44780_functions->scankeypad = serial_HD44780_scankeypad;
 	p->hd44780_functions->close = serial_HD44780_close;
 
+	/* Do pre-initialization */
+	if (SERIAL_IF.pre_init) {
+		serial_HD44780_senddata(p, 0, RS_INSTR,
+			SERIAL_IF.pre_init);
+		p->hd44780_functions->uPause(p, 40);
+	}
+	
 	/* Do initialization */
 	if (SERIAL_IF.if_bits == 8) {
 		report(RPT_INFO,"HD44780: serial: initializing with 8 bits interface");
@@ -289,7 +298,9 @@ serial_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char f
 	}
 	else {
 		write(p->fd, &SERIAL_IF.instruction_escape, 1);
+		p->hd44780_functions->uPause(p, SERIAL_IF.instruction_pause*1000);
 		write(p->fd, &ch, 1);
+		p->hd44780_functions->uPause(p, SERIAL_IF.instruction_pause*1000);
 	}
 	lastdisplayID = displayID;
 }
@@ -331,16 +342,25 @@ serial_HD44780_backlight(PrivateData *p, unsigned char state)
 /**
  * Read keypress.
  * \param p  Pointer to driver's private data structure.
- * \return   Scancode of the pressed keys.
+ * \return   Scancode of the pressed key
  */
 unsigned char
 serial_HD44780_scankeypad(PrivateData *p)
 {
-	unsigned char buffer = 0;
+
+	struct pollfd pfd = { .fd = p->fd, .events = POLLIN };
+	unsigned char buffer;
 	char hangcheck = 100;
 
-	read(p->fd, &buffer, 1);
-	if (buffer == SERIAL_IF.keypad_escape) {
+	if (SERIAL_IF.keypad_command) {
+	
+		serial_HD44780_senddata(p, 0, RS_INSTR, SERIAL_IF.keypad_command);
+
+		if (poll(&pfd, 1, 250) != 1)
+			return 0;
+	}
+	
+	if (read(p->fd, &buffer, 1) == 1 && buffer == SERIAL_IF.keypad_escape) {
 		while (hangcheck > 0) {
 			/* Check if I can read another byte */
 			if (read(p->fd, &buffer, 1) == 1) {
@@ -362,16 +382,23 @@ serial_HD44780_scankeypad(PrivateData *p)
 					}
 					return retval;
 				}
-				else {
-					return buffer;
+				if (SERIAL_IF.connectiontype == HD44780_CT_EZIO) {
+					switch (buffer) {
+						case 0x4E:	return 0x44;
+						case 0x4D:	return 0x24;
+						case 0x4B:	return 0x14;
+						case 0x47:	return 0x34;
+						default:	return 0;
+					}
 				}
+				return buffer;
 			}
 			hangcheck--;
 		}
 	}
-	return '\0';
-}
 
+	return 0;
+}
 
 /**
  * Close the driver (do necessary clean-up).

--- a/server/drivers/hd44780-serial.c
+++ b/server/drivers/hd44780-serial.c
@@ -385,21 +385,21 @@ serial_HD44780_scankeypad(PrivateData *p)
 				if (SERIAL_IF.connectiontype == HD44780_CT_EZIO) {
 					/* Support EZIO-100 0x4n and EZIO-300 0xBn */
 					switch (buffer) {
-						case 0x4B:
-						case 0xBB:
-							return 0x14;	/* KeyMatrix_4_1=Enter  */
-						case 0x4D:
-						case 0xBE:
-							return 0x24;	/* KeyMatrix_4_2=Up     */
-						case 0x47:
-						case 0xBD:
-							return 0x34;	/* KeyMatrix_4_3=Down   */
-						case 0x4E:
-						case 0xB7:
-							return 0x44;	/* KeyMAtrix_4_4=Escape */
-						/* No key 0x4F/0xBF or more than one key */ 
-						default:
-							return 0;
+					    case 0x4B:
+					    case 0xBB:
+						return 0x14;	/* KeyMatrix_4_1=Enter  */
+					    case 0x4D:
+					    case 0xBE:
+						return 0x24;	/* KeyMatrix_4_2=Up     */
+					    case 0x47:
+					    case 0xBD:
+						return 0x34;	/* KeyMatrix_4_3=Down   */
+					    case 0x4E:
+					    case 0xB7:
+						return 0x44;	/* KeyMAtrix_4_4=Escape */
+					    /* No key 0x4F/0xBF or more than one key */ 
+					    default:
+						return 0;
 					}
 				}
 				return buffer;

--- a/server/drivers/hd44780-serial.c
+++ b/server/drivers/hd44780-serial.c
@@ -383,12 +383,23 @@ serial_HD44780_scankeypad(PrivateData *p)
 					return retval;
 				}
 				if (SERIAL_IF.connectiontype == HD44780_CT_EZIO) {
+					/* Support EZIO-100 0x4n and EZIO-300 0xBn */
 					switch (buffer) {
-						case 0x4E:	return 0x44;
-						case 0x4D:	return 0x24;
-						case 0x4B:	return 0x14;
-						case 0x47:	return 0x34;
-						default:	return 0;
+						case 0x4B:
+						case 0xBB:
+							return 0x14;	/* KeyMatrix_4_1=Enter  */
+						case 0x4D:
+						case 0xBE:
+							return 0x24;	/* KeyMatrix_4_2=Up     */
+						case 0x47:
+						case 0xBD:
+							return 0x34;	/* KeyMatrix_4_3=Down   */
+						case 0x4E:
+						case 0xB7:
+							return 0x44;	/* KeyMAtrix_4_4=Escape */
+						/* No key 0x4F/0xBF or more than one key */ 
+						default:
+							return 0;
 					}
 				}
 				return buffer;

--- a/server/drivers/hd44780-serial.h
+++ b/server/drivers/hd44780-serial.h
@@ -21,9 +21,11 @@ struct hd44780_SerialInterface {
 	 * data_escape_max.
 	 *@{*/
 	unsigned char instruction_escape;	/**< Instruction escape character. */
+	unsigned int  instruction_pause;	/**< Instruction pause in ms */
 	unsigned char data_escape;	/**< Data escape character. */
 	unsigned char data_escape_min;	/**< Escaped data lower limit (inclusive) */
 	unsigned char data_escape_max;	/**< Escaped data upper limit (inclusive) */
+	unsigned char pre_init;		/**< Command to send prior to common initialization */
 	/**@}*/
 
 	unsigned int  default_bitrate;	/**< Bitrate device is set to by default */
@@ -33,6 +35,7 @@ struct hd44780_SerialInterface {
 	 *@{*/
 	char          keypad;		/**< Flag: keypad available */
 	unsigned char keypad_escape;	/**< Keys are escaped with this character */
+	unsigned char keypad_command;	/**< Command to request keys */
 	/**@}*/
 
 	/** \name Backlight options
@@ -65,14 +68,14 @@ struct hd44780_SerialInterface {
  * here, remember also to change hd44780-drivers.h as well.
  */
 static const struct hd44780_SerialInterface serial_interfaces[] = {
-	/*    type                  instr data     v     ^ bitrate bits  K   esc  B  Besc  Boff   Bon Multi  End */
-	{ HD44780_CT_PICANLCD,      0x11, 0x12, 0x00, 0x1F,   9600,   8, 0, 0x00, 0,    0,    0,    0,   0,    0 },
-	{ HD44780_CT_LCDSERIALIZER, 0xFE,    0, 0x00, 0x00,   9600,   8, 0, 0x00, 0,    0,    0,    0,   0,    0 },
-	{ HD44780_CT_LOS_PANEL,     0xFE,    0, 0x00, 0x00,   9600,   4, 1, 0xFE, 1, 0xFD,    0, 0xFF,   0,    0 },
-	{ HD44780_CT_VDR_LCD,       0xFE,    0, 0x00, 0x00,   9600,   4, 0, 0x00, 0,    0,    0,    0,   0,    0 },
-	{ HD44780_CT_VDR_WAKEUP,    0xC0, 0xC4, 0xC0, 0xCF,   9600,   4, 0, 0x00, 1,    0, 0xC9, 0xC8,   1, 0xCF },
-	{ HD44780_CT_PERTELIAN,     0xFE,    0, 0x00, 0x00,   9600,   8, 0, 0x00, 1, 0xFE, 0x02, 0x03,   0,    0 },
-	{ HD44780_CT_UNKNOWN, 0x00, 0, 0x00, 0x00, 0, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0, 0 }
+	/*    type                  instr ms  data     v     ^   pre bitrate bits  K   esc   cmd  B  Besc  Boff   Bon Multi  End */
+	{ HD44780_CT_PICANLCD,      0x11,  0, 0x12, 0x00, 0x1F,    0,   9600,   8, 0, 0x00,    0, 0,    0,    0,    0,   0,    0 },
+	{ HD44780_CT_LCDSERIALIZER, 0xFE,  0,    0, 0x00, 0x00,    0,   9600,   8, 0, 0x00,    0, 0,    0,    0,    0,   0,    0 },
+	{ HD44780_CT_LOS_PANEL,     0xFE,  0,    0, 0x00, 0x00,    0,   9600,   4, 1, 0xFE,    0, 1, 0xFD,    0, 0xFF,   0,    0 },
+	{ HD44780_CT_VDR_LCD,       0xFE,  0,    0, 0x00, 0x00,    0,   9600,   4, 0, 0x00,    0, 0,    0,    0,    0,   0,    0 },
+	{ HD44780_CT_VDR_WAKEUP,    0xC0,  0, 0xC4, 0xC0, 0xCF,    0,   9600,   4, 0, 0x00,    0, 1,    0, 0xC9, 0xC8,   1, 0xCF },
+	{ HD44780_CT_PERTELIAN,     0xFE,  0,    0, 0x00, 0x00,    0,   9600,   8, 0, 0x00,    0, 1, 0xFE, 0x02, 0x03,   0,    0 },
+	{ HD44780_CT_EZIO,          0xFE, 40,    0, 0x00, 0x00, 0x28,   2400,   4, 1, 0xFD, 0x06, 0,    0,    0,    0,   0,    0 }
 };
 
 /* initialize this particular driver */

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -313,7 +313,7 @@ HD44780_init(Driver *drvthis)
 				/* Was a key specified in the config file ? */
 				if (s) {
 					p->keyMapMatrix[y][x] = strdup(s);
-					report(RPT_INFO, "HD44780: Matrix key %d %d: \"%s\"", x, y, s);
+					report(RPT_INFO, "HD44780: Matrix key %d %d: \"%s\"", x+1, y+1, s);
 				}
 			}
 		}


### PR DESCRIPTION
I wanted to propose a code change to add support for yet another variation of the HD44780 driver: the Portwell EZIO-100 and EZIO-300 devices. These devices come built-in some firewall appliances and have some popularity in the pfSense community.

![](https://www.portwell.com.tw/images/p_img/large/EZIO-100.jpg)

![](http://www.portwell.com/im/ca/EZIO-300-v.jpg)

Portwell put a serial interface "in front" of the LCD controller. The serial device has a couple of differences compared to other serial interfaces already implemented. The initialization sequence is "repeated", and a command has to be sent in order to receive the keypad status.

A concern is that I only own this particular EZIO-100 device, so that is the only one I can test. I therefore tried to minimize the possibility of accidentally breaking support for other devices by updating the main struct in the serial code.

The documentation is [here](http://drivers.portwell.com/CA_Manual/).

Thanks for considering this request for inclusion into the project. I will do a follow-up pull request for the updated documentation.