### PR TITLE
Add configuration for "Standard C" C99

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ fi
 
 dnl Checks for programs used in building
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_RANLIB


### PR DESCRIPTION
This is the proposed code fix for #81 

The purpose is to formally declare that the project code is in compliance with "Standard C", currently C99. Not doing this means the C dialect defaults to whatever a given compiler defaults to.

The practical aspect is that when this code is compiled with an older compiler defaulting to C89, but supporting C99, the support for C99 is actually turned on.

There is documentation here: [C Compiler Characteristics](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/C-Compiler.html)

[C99 on Wikipedia](https://en.wikipedia.org/wiki/C99)

Thanks for considering merging this into the project.