### PR TITLE
Add missing ioctl header

### DIFF
--- a/server/drivers/hd44780-pifacecad.c
+++ b/server/drivers/hd44780-pifacecad.c
@@ -54,6 +54,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <linux/ioctl.h>
 #include <stdint.h>
 #include <linux/spi/spidev.h>
 

--- a/server/drivers/hd44780-spi.c
+++ b/server/drivers/hd44780-spi.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <linux/ioctl.h>
 #include <stdint.h>
 #include <linux/spi/spidev.h>
 


### PR DESCRIPTION
The spidev.h header uses macros from linux/ioctl.h. Add this header
explicitly since some libc, like musl, do not include it implicitly.
This fixes the following build failure:

In file included from .../sysroot/usr/include/sys/ioctl.h:7:0,
                 from hd44780-spi.c:31:
hd44780-spi.c: In function ‘spi_transfer’:
hd44780-spi.c:89:24: error: ‘_IOC_SIZEBITS’ undeclared (first use in this function)
  status = ioctl(p->fd, SPI_IOC_MESSAGE(1), &xfer);
                        ^