### PR TITLE
Add support for HD44780-compatible WINSTAR WEH00xxyyA OLED Displays

### DIFF
--- a/LCDd.conf
+++ b/LCDd.conf
@@ -598,6 +598,28 @@ Size=20x4
 # than one display!
 #ExtendedMode=yes
 
+# Some OLED displays (particularly WINSTAR WEH001602A, WEH002002A, and others)
+# require slightly different initialization sequence, which is particularly important
+# on reinitializations without powering off display. If you have this kind 
+# of display and have garbage on it after restarting LCDd, turn this option to TRUE.
+# By default it is FALSE.
+#WinstarMode=yes
+
+# WINSTAR OLED WEH001602A and compatible have two levels of brightness 
+# (full and dimmed), which can be set using special LCD command, not with
+# dedicated backlight pin. This option if enabled maps backlight setting 
+# to these two levels of brightness, depending on values of options (respectively)
+# Brightness and OffBrightness, any value below 500 causes dimmed brightness;
+# >= 500 causes full brightness.
+#
+# If this option is OFF, brightness setting is not managed with backlight, but it is
+# set to constant value at time of initialization, depending on configured Brightness
+# setting.
+#
+# By default it is set, as it appears to be common usage. Works only when WinstarMode
+# is turned ON, otherwise it is ignored.
+WinstarMapBl=no
+
 # In extended mode, on some controllers like the ST7036 (in 3 line mode)
 # the next line in DDRAM won't start 0x20 higher. [default: 0x20]
 #LineAddress=0x10

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3772,6 +3772,57 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
 
 <varlistentry>
   <term>
+    <property>WinstarMode</property> = &parameters.yesnodef;
+  </term>
+  <listitem><para>
+      Some OLED displays (particularly WINSTAR WEH001602A, WEH002002A, and others)
+      require slightly different initialization sequence, which is particularly important
+      on reinitializations without powering off display. If you have this kind 
+      of display and have garbage on it after restarting LCDd, turn this option to TRUE.
+    
+      Default: <literal>no</literal>.
+  </para></listitem>
+</varlistentry>
+
+<varlistentry>
+  <term>
+    <property>WinstarMapBl</property> = &parameters.yesnodef;
+  </term>
+  <listitem>
+    <para>
+      This option works only when <literal>WinstarMode</literal> is turned ON, otherwise it is ignored.
+    </para>
+    <para>
+      WINSTAR OLED WEH001602A and compatible have two levels of brightness 
+      (dimmed and full), which can be set using special LCD command, not with dedicated
+      backlight pin. This option if enabled maps backlight setting to these two levels of brightness,
+      depending on values of options <literal>Brightness</literal> and <literal>OffBrightness</literal>:
+      <itemizedlist>
+        <listitem><para>
+          <literal>&lt;500</literal> causes dimmed brightness
+        </para></listitem>
+        <listitem><para>
+          <literal>&gt;=500</literal> causes full brightness.
+        </para></listitem>
+      </itemizedlist>
+    </para>
+    <para>
+      If this option is OFF, brightness setting is not managed with backlight, but it is
+      set to constant value at time of initialization, depending on configured setting
+      of <literal>Brightness</literal>.
+  </para>    
+    <para>           
+      By default it is set to <literal>yes</literal>, as it appears to be common usage.
+      With default values of <literal>Brightness</literal> <literal>(300)</literal> and 
+      <literal>OffBrightness</literal> <literal>(800)</literal>,
+      when backlight is OFF, OLED display is dimmed and lights at full brightness when Backlight is ON.
+    </para>
+    </listitem>
+</varlistentry>
+
+
+<varlistentry>
+  <term>
     <property>ExtendedMode</property> = &parameters.yesnodef;
   </term>
   <listitem><para>

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -234,6 +234,13 @@ typedef struct hd44780_private_data {
 	int delayMult;		/**< Delay multiplier for slow displays */
 	char delayBus;		/**< Delay if data is sent too fast over LPT port */
 
+	char winstar_mode;	/**< is Winstar OLED compatible? If yes, it needs special initialization routine
+	                             and enables handling of display brightness as below: */
+	char winstar_map_bl;	/**< This sets enables handling of brightness of display based on backlight state,
+	                             by default it is only managed by brightness setting.
+	                             This uses nonstandard command, Internal Power function */
+
+
 	/**
 	 * lastline controls the use of the last line, if pixel addressable
 	 * (true, default) or underline effect (false). To avoid the
@@ -419,6 +426,14 @@ void common_init(PrivateData *p, unsigned char if_bit);
 
 /** Shift or scroll enable (RE=1) */
 #define HSCROLLEN	0x10
+
+/** Extra definitions on Winstar OLED displays - set last 2 bits (=0x03) to activate */
+#define WINST_MODESET	0x13	/**< required bits for command */
+#define WINST_TEXTMODE	0x00	/**< Activate text mode */
+#define WINST_GRAPHMODE	0x08	/**< Activate graphic mode */
+#define WINST_PWRON	0x04	/**< Internal power on (high brightness)*/
+#define WINST_PWROFF	0x00	/**< Internal power off (low brightness)*/
+
 
 /** Function set (RE=0) */
 #define FUNCSET		0x20

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -484,16 +484,18 @@ common_init(PrivateData *p, unsigned char if_bit)
 		p->hd44780_functions->uPause(p, 40);
 	}
 
-	if (p->winstar_mode) {
-		p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPOFF | CURSOROFF | CURSORNOBLINK);
-		p->hd44780_functions->uPause(p, 40);
-	}
+	/* First turn display off */
+	p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPOFF | CURSOROFF | CURSORNOBLINK);
+	p->hd44780_functions->uPause(p, 40);
 
+	/* perform initialization in off state, so it does not cause flickering and other strange things */
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | p->font_bank);
 	p->hd44780_functions->uPause(p, 40);
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, ENTRYMODE | E_MOVERIGHT | NOSCROLL);
 	p->hd44780_functions->uPause(p, 40);
 	if (p->winstar_mode) {
+		/* For WINSTAR OLED displays need to set TEXT mode and additionally level of brigtness.
+		 * It is particularly important on reinitialization without powering off it first */
 		unsigned char pwr = WINST_PWROFF;
 		if (!p->winstar_map_bl && p->brightness >= 500) {
 			pwr = WINST_PWRON;


### PR DESCRIPTION
Added support for WINSTAR OLED displays - almost compatible to
HD44780 LCDs. These displays require slightly different initialization sequence,
especially required on display reinitialization without powering it off first.

Also added support for handling backlight using built-in command
for brightness setting.

Tested on Raspberry PI and WINSTAR WEH001604ALPP5N00001 OLED display
connected through I2C PCF8574 connection (4-bits obviously) and
WINSTAR WEH002004ALPP5N00001 OLED. Should work on any connection.