### PR TITLE
Add support for HD44780-compatible WINSTAR WEH00xxyyA OLED Displays - try 2

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -458,3 +458,10 @@ flexible :)
   - Parallel Port LCD driver for the Watchguard/Lanner firewall appliances (sdeclcd)
 
   - Supplemented HD44780 serial driver to support Portwell EZIO-100 and EZIO-300 LCDs found in Portwell, Caswell and Check Point firewall appliances
+
+- [Michał Skalski](mailto:mskalski13@gmail.com)
+
+  - Support for HD44780-compatible Winstar OLED displays: WEH001604A, WEH002004A and similar in hd44780 driver
+
+  - Added to HD44780 driver support for internal backlight handling (by means of levels of brightness)
+    for Winsar OLED and PTC PT6314 VFD (for the latter credits go to trex2000 GitHub user).

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -599,7 +599,9 @@ Keypad=no
 #          as catch up (last resort) for other types of displays which have similar features.
 #
 # You can combine external, internal and internalCmds separating them with comma or pipe (|) character,
-# to use more than one method
+# to use more than one method.
+# Default is model specific: Winstar OLED and PT6314 VFD enables internal backlight mode,
+# for others it is set to none.
 #Backlight = none
 
 # Commands for enabling internal backlight for use with Backlight=internalCmds.

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -584,8 +584,37 @@ Keypad=no
 # [default: 300; legal: 0 - 1000]
 #OffBrightness=0
 
-# If you have a switchable backlight.
-Backlight=no
+# Specify if you have a switchable backlight and if yes, can select method for turning it on/off:
+#
+# - none - no switchable backlight is available. For compability also boolean
+#          0, n, no, off and false are aliases.
+# - external - use external pin or any other method defined with ConnectionType backlight
+#          handling. For backward compability also this value is chosen for boolean
+#          TRUE values: 1, y, yes, on and true.
+# - internal - means that backlight is handled using internal commands according
+#          to selected display model (with Model option). Depending on model,
+#          Brightness and OffBrightness options can be taken into account.
+# - internalCmds - means that commands for turning on and off backlight are given
+#          with extra options BacklightOnCmd and BacklightOffCmd, which would be treated
+#          as catch up (last resort) for other types of displays which have similar features.
+#
+# You can combine external, internal and internalCmds separating them with comma or pipe (|) character,
+# to use more than one method
+#Backlight = none
+
+# Commands for enabling internal backlight for use with Backlight=internalCmds.
+# Up to 4 bytes can be encoded, as integer number in big-endian order.
+#
+# NOTE: this is advanced option, if command contains bits other than only brighness handling,
+# they must be set accordingly to not disrupt display state. If for example 'FUNCTION SET' command
+# is used for this purpose, bits of interface length (4-bit / 8-bit) must be set according to
+# selected ConnectionType.
+#BacklightCmdOn=0x1223
+
+# Commands for disabling internal backlight for use with Backlight=internalCmds.
+# Up to 4 bytes can be encoded, as integer number in big-endian order.
+#BacklightCmdOff=0x1234
+
 
 # If you have the additional output port ("bargraph") and you want to
 # be able to control it with the lcdproc OUTPUT command
@@ -609,6 +638,7 @@ Size=20x4
 # As an additional restriction, controllers with and without extended mode
 # AND 4 lines cannot be mixed for those connection types that support more
 # than one display!
+# NOTE: This option is deprecated in favour of choosing Model=extended option.
 #ExtendedMode=yes
 
 # In extended mode, on some controllers like the ST7036 (in 3 line mode)

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -544,13 +544,13 @@ Speed=19200
 # Select what type of connection. See documentation for available types.
 ConnectionType=4bit
 
-# Select model if have non-standard one which require extra initailization or handling or
-# just want extra features they offer.
+# Select model if have non-standard one which require extra initialization or handling or
+# just want extra features it offers.
 # Available: standard (default), extended, winstar_oled, pt6314_vfd
 # - standard is default, use for LCDs not mentioned below.
-# - extended or ks0073: allows use 4-line "extended" mode,
+# - extended, hd66712, ks0073: allows use 4-line "extended" mode,
 #   same as deprecated now option ExtendedMode=yes
-# - winstar_oled: changes initialization for WINSTAR's WEH00xxyyA displays
+# - winstar_oled, weh00xxyya: changes initialization for WINSTAR's WEH00xxyyA displays
 #   and allows handling brightness
 # - pt6314_vfd: allows handling brightness on PTC's PT6314 VFDs
 #

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -544,6 +544,19 @@ Speed=19200
 # Select what type of connection. See documentation for available types.
 ConnectionType=4bit
 
+# Select model if have non-standard one which require extra initailization or handling or
+# just want extra features they offer.
+# Available: standard (default), extended, winstar_oled, pt6314_vfd
+# - standard is default, use for LCDs not mentioned below.
+# - extended or ks0073: allows use 4-line "extended" mode,
+#   same as deprecated now option ExtendedMode=yes
+# - winstar_oled: changes initialization for WINSTAR's WEH00xxyyA displays
+#   and allows handling brightness
+# - pt6314_vfd: allows handling brightness on PTC's PT6314 VFDs
+#
+# This option should be independent of connection type.
+#Model = standard
+
 # I/O address of the LPT port. Usual values are: 0x278, 0x378 and 0x3BC.
 # For I2C connections this sets the slave address (usually 0x20).
 Port=0x378

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -598,8 +598,7 @@ Keypad=no
 #          with extra options BacklightOnCmd and BacklightOffCmd, which would be treated
 #          as catch up (last resort) for other types of displays which have similar features.
 #
-# You can combine external, internal and internalCmds separating them with comma or pipe (|) character,
-# to use more than one method.
+# You can provide multiple occurences of this option to use more than one method.
 # Default is model specific: Winstar OLED and PT6314 VFD enables internal backlight mode,
 # for others it is set to none.
 #Backlight = none

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3536,27 +3536,27 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
           is for "classic" HD44780 displays.
         </para></listitem>
         <listitem><para>
-          <literal>extended</literal> or <literal>ks0073</literal> is for displays
-          which have "extended mode" turned on with special instruction.
-          If you have a KS0073 or an other 'almost HD44780-compatible', set
-          <literal>Model</literal> to this value to get into extended,
-          4-line linear addressing mode.
+          <literal>extended</literal>, <literal>hd66712</literal> or <literal>ks0073</literal>
+          is for displays which have "extended mode" turned on with special instruction.
+          If you have a Samsung KS0073, PowerTip Corp. PC2004LRU, other based on HD66710/HD66712 chip
+          or an other 'almost HD44780-compatible', set  <literal>Model</literal> to
+          this value to get into extended, 4-line linear addressing mode.
         </para>
         <para>
           Use this instead of deprecated option <literal>ExtendedMode</literal>.
         </para></listitem>
         <listitem><para>
-          <literal>winstar_oled</literal> is for WINSTAR WEH00xxyyA OLED displays
-          and allows performing proper initialization of display device,
-          especially after display reset without powering it off.
+          <literal>winstar_oled</literal> or <literal>weh00xxyya</literal> is for
+          WINSTAR WEH00xxyyA OLED displays and allows performing proper initialization
+          of display device, especially after display reset without powering it off.
         </para>
         <para>It also allows handling backlight setting using internal commands
         for such displays.
         </para>
         </listitem>
         <listitem><para>
-          <literal>pt6314_vfd</literal> is for some PTC's PT6314 VFDs and allows
-          handling brightness of display.
+          <literal>pt6314_vfd</literal> is for some Princeton Technology Corp.'s
+          PT6314 VFDs and allows handling brightness of display.
         </para></listitem>
       </itemizedlist>
       You only may need to set this parameter if you have a non-standard

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -2585,7 +2585,7 @@ If your port expander has different wiring you can re-assign the pins in the con
 </para>
 
 <example id="hd44780-i2c-config.example.alternative.wiring">
-<title>HD44780: Configuration for I<superscript>2</superscript>C with port expander 
+<title>HD44780: Configuration for I<superscript>2</superscript>C with port expander
 Alternative Wiring</title>
 <screen>
 <![CDATA[
@@ -2619,7 +2619,7 @@ i2c_line_D6=0x40
 i2c_line_D7=0x80
 Backlight=yes
 BacklightInvert=yes
-#The Backlight Invert is used if a 0 turns the backlight on, and 1 turns it off, 
+#The Backlight Invert is used if a 0 turns the backlight on, and 1 turns it off,
 i.e. PNP transistor
 ]]>
 </screen>
@@ -3514,6 +3514,64 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
 
 <varlistentry>
   <term>
+    <property>Model</property> =
+    {
+      <!-- Keep this list sorted according to the table in hd44780-low.h -->
+      <emphasis><parameter><literal>standard</literal></parameter></emphasis> |
+      <parameter><literal>extended</literal></parameter> |
+      <parameter><literal>winstar_oled</literal></parameter> |
+      <parameter><literal>pt6314_vfd</literal></parameter>
+    }
+  </term>
+  <listitem>
+    <para>
+      Some devices (ie. WINSTAR WEH001602A OLED or PTC PT6314 VFD) require additional
+      initialization or configuration incompatible with "classic" LCD or just have extra
+      features, such as internal commands for brightness handling. If you have such display
+      setting this option may help in problems with initialization or adds extra
+      functionality.
+      <itemizedlist>
+        <listitem><para>
+          The default, <literal>standard</literal> or <literal>default</literal>,
+          is for "classic" HD44780 displays.
+        </para></listitem>
+        <listitem><para>
+          <literal>extended</literal> or <literal>ks0073</literal> is for displays
+          which have "extended mode" turned on with special instruction.
+          If you have a KS0073 or an other 'almost HD44780-compatible', set
+          <literal>Model</literal> to this value to get into extended,
+          4-line linear addressing mode.
+        </para>
+        <para>
+          Use this instead of deprecated option <literal>ExtendedMode</literal>.
+        </para></listitem>
+        <listitem><para>
+          <literal>winstar_oled</literal> is for WINSTAR WEH00xxyyA OLED displays
+          and allows performing proper initialization of display device,
+          especially after display reset without powering it off.
+        </para>
+        <para>It also allows handling backlight setting using internal commands
+        for such displays.
+        </para>
+        </listitem>
+        <listitem><para>
+          <literal>pt6314_vfd</literal> is for some PTC's PT6314 VFDs and allows
+          handling brightness of display.
+        </para></listitem>
+      </itemizedlist>
+      You only may need to set this parameter if you have a non-standard
+      HD44780 display such as specified above and have problems with it and/or
+      want reveal extra functionality with these displays.
+    </para>
+    <para>
+      This option should be independent of connection type.
+    </para>
+  </listitem>
+</varlistentry>
+
+
+<varlistentry>
+  <term>
     <property>Speed</property> =
     <parameter><replaceable>BITRATE</replaceable></parameter>
   </term>
@@ -3645,7 +3703,15 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
       </itemizedlist>
       You only need to set this parameter if you have a HD44780 display
       such as the WINSTAR WEH001602A, which allows selecting the font bank
-      during initialization.
+      during initialization. Additionally you may need to set correct
+      <literal>CharMap</literal>.
+      <note>
+      <para>Setting this to nonzero value on standard HD44780 is usually harmless,
+      but some non-standard displays may use bits used for <literal>FontBank</literal>
+      selection, so it is safer to leave this option at default value for displays
+      not supporting Font bank.
+      </para>
+      </note>
     </para>
   </listitem>
 </varlistentry>
@@ -3777,7 +3843,10 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
   <listitem><para>
     If you have a KS0073 or an other 'almost HD44780-compatible', set this
     flag to get into extended,4-line linear addressing mode.
-  </para></listitem>
+  </para>
+  <note><para>
+    Deprecated, use <code>Model=extended</code> for such displays.
+  </para></note></listitem>
 </varlistentry>
 
 <varlistentry>

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3805,17 +3805,49 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
             extra options <literal>BacklightOnCmd</literal> and <literal>BacklightOffCmd</literal>,
             which would be treated as catch up (last resort) for other types of displays which have similar features.
           </para>
-          <note><para>
-           This is advanced option, if command contains bits other than only brighness handling, they must be
-           set accordingly to not disrupt display state. If for example 'FUNCTION SET' command is used for this
-           purpose, bits of interface length (4-bit / 8-bit) must be set according to selected ConnectionType.
-         </para></note>
         </listitem>
       </itemizedlist>
     </para>
-    <para>It is possible to combine <literal>external</literal>,  <literal>internal</literal> and <literal>internalCmds</literal>
+    <para>
+      You can combine <literal>external</literal>, <literal>internal</literal> and <literal>internalCmds</literal>
+      separating them with comma or pipe (<literal>|</literal>) character, to use more than one method.
+      This can be useful for example for glowing buttons with external pin when backlight is on and
+      using internal command to set high brightness of display.
     </para>
   </listitem>
+</varlistentry>
+
+
+<varlistentry>
+  <term>
+    <property>BacklightCmdOn</property> =
+    <parameter><replaceable>COMMAND(s)</replaceable></parameter>
+  </term>
+  <listitem><para>
+    Commands for enabling internal backlight for use with <literal>Backlight=internalCmds</literal>.
+    Up to 4 bytes can be encoded, as integer number (hex) in big-endian order.
+    Ignored if <literal>Backlight</literal> does not specify <literal>internalCmds</literal>,
+    required otherwise.
+  </para>
+  <note><para>
+    This is advanced option, if command contains bits other than only brighness handling, they must be
+    set accordingly to not disrupt display state. If for example 'FUNCTION SET' command is used for this
+    purpose, bits of interface length (4-bit / 8-bit) must be set according to selected ConnectionType.
+   </para></note>
+  </listitem>
+</varlistentry>
+
+<varlistentry>
+  <term>
+    <property>BacklightCmdOff</property> =
+    <parameter><replaceable>COMMAND(s)</replaceable></parameter>
+  </term>
+  <listitem><para>
+    Commands for disabling internal backlight for use with <literal>Backlight=internalCmds</literal>.
+    Up to 4 bytes can be encoded, as integer number (hex) in big-endian order.
+    Ignored if <literal>Backlight</literal> does not specify <literal>internalCmds</literal>,
+    required otherwise. See above note about <literal>BacklightCmdOn</literal>.
+  </para></listitem>
 </varlistentry>
 
 <varlistentry>

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3814,6 +3814,10 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
       This can be useful for example for glowing buttons with external pin when backlight is on and
       using internal command to set high brightness of display.
     </para>
+    <para>
+       Default is model specific (depends on <literal>Model</literal> option): Winstar OLED and PT6314 VFD
+       enables <literal>internal</literal> backlight mode,for others it is set to <literal>none</literal>.
+    </para>
   </listitem>
 </varlistentry>
 

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3809,14 +3809,13 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
       </itemizedlist>
     </para>
     <para>
-      You can combine <literal>external</literal>, <literal>internal</literal> and <literal>internalCmds</literal>
-      separating them with comma or pipe (<literal>|</literal>) character, to use more than one method.
+      You can provide multiple occurences of this option to use more than one method.
       This can be useful for example for glowing buttons with external pin when backlight is on and
       using internal command to set high brightness of display.
     </para>
     <para>
        Default is model specific (depends on <literal>Model</literal> option): Winstar OLED and PT6314 VFD
-       enables <literal>internal</literal> backlight mode,for others it is set to <literal>none</literal>.
+       enables <literal>internal</literal> backlight mode, for others it is set to <literal>none</literal>.
     </para>
   </listitem>
 </varlistentry>

--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -3771,11 +3771,51 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
 
 <varlistentry>
   <term>
-    <property>Backlight</property> = &parameters.yesnodef;
+    <property>Backlight</property> =
+    {
+      <emphasis><parameter><literal>none</literal></parameter></emphasis> |
+      <parameter><literal>external</literal></parameter> |
+      <parameter><literal>internal</literal></parameter> |
+      <parameter><literal>internalCmds</literal></parameter>
+    }
   </term>
-  <listitem><para>
-    Specify if you have a switchable backlight.
-  </para></listitem>
+  <listitem>
+    <para>
+      Specify if you have a switchable backlight and if yes, can select method for
+      turning it on/off:
+      <itemizedlist>
+        <listitem><para>
+          <literal>none</literal> - no switchable backlight is available.
+          For compability also boolean <literal>0</literal>, <literal>n</literal>,
+          <literal>no</literal>, <literal>off</literal> and <literal>false</literal> are aliases.
+        </para></listitem>
+        <listitem><para>
+          <literal>external</literal> - use external pin or any other method defined with <literal>ConnectionType</literal>
+          backlight handling. For backward compability also this value is chosen for boolean TRUE values:
+          <literal>1</literal>, <literal>y</literal>, <literal>yes</literal>, <literal>on</literal> and <literal>true</literal>.
+        </para></listitem>
+        <listitem><para>
+          <literal>internal</literal> means that backlight is handled using internal commands according to
+          selected display model (with <literal>Model</literal> option).
+          Depending on model, <literal>Brightness</literal> and <literal>OffBrightness</literal> options can be taken into account.
+        </para></listitem>
+        <listitem>
+          <para>
+            <literal>internalCmds</literal> means that commands for turning on and off backlight are given with
+            extra options <literal>BacklightOnCmd</literal> and <literal>BacklightOffCmd</literal>,
+            which would be treated as catch up (last resort) for other types of displays which have similar features.
+          </para>
+          <note><para>
+           This is advanced option, if command contains bits other than only brighness handling, they must be
+           set accordingly to not disrupt display state. If for example 'FUNCTION SET' command is used for this
+           purpose, bits of interface length (4-bit / 8-bit) must be set according to selected ConnectionType.
+         </para></note>
+        </listitem>
+      </itemizedlist>
+    </para>
+    <para>It is possible to combine <literal>external</literal>,  <literal>internal</literal> and <literal>internalCmds</literal>
+    </para>
+  </listitem>
 </varlistentry>
 
 <varlistentry>

--- a/server/drivers/hd44780-4bit.c
+++ b/server/drivers/hd44780-4bit.c
@@ -262,7 +262,7 @@ lcdstat_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char 
  */
 void lcdstat_HD44780_backlight(PrivateData *p, unsigned char state)
 {
-	p->backlight_bit = ((!p->have_backlight||state)?0:BL);
+	p->backlight_bit = ((have_backlight_pin(p)||state)?0:BL);
 
 	port_out(p->port, p->backlight_bit);
 }
@@ -279,7 +279,7 @@ unsigned char lcdstat_HD44780_readkeypad(PrivateData *p, unsigned int YData)
 	unsigned char readval;
 
 	/* If at most two controllers and NO backlight, 10 bits may be used */
-	if ((p->numDisplays <= 2) && (!p->have_backlight)) {
+	if ((p->numDisplays <= 2) && (have_backlight_pin(p))) {
 		port_out(p->port, ~YData & 0x003F);
 		port_out(p->port + 2, (((~YData & 0x03C0) >> 6)) ^ OUTMASK);
 	}

--- a/server/drivers/hd44780-ext8bit.c
+++ b/server/drivers/hd44780-ext8bit.c
@@ -181,7 +181,7 @@ unsigned char lcdtime_HD44780_readkeypad(PrivateData *p, unsigned int YData)
 	// Convert the positive logic to the negative logic on the LPT port
 	port_out(p->port, ~YData & 0x00FF);
 	// 9 bits output if backlight is used, 10 bits otherwise
-	if (p->have_backlight)
+	if (have_backlight_pin(p))
 		port_out(p->port + 2, (((~YData & 0x0100) >> 8) | p->backlight_bit) ^ OUTMASK);
 	else
 		port_out(p->port + 2, (((~YData & 0x0100) >> 8) | ((~YData & 0x0200) >> 6)) ^ OUTMASK);

--- a/server/drivers/hd44780-gpio.c
+++ b/server/drivers/hd44780-gpio.c
@@ -81,7 +81,7 @@ init_gpio_pin(Driver *drvthis, ugpio_t **pin, const char *name)
 		return -1;
 	}
 
-	debug(RPT_INFO, "init_gpio_pin: Pin %s mapped to GPIO%d", name, number);
+	report(RPT_INFO, "init_gpio_pin: Pin %s mapped to GPIO%d", name, number);
 
 	return 0;
 }
@@ -159,11 +159,11 @@ hd_init_gpio(Driver *drvthis)
 	p->hd44780_functions->senddata = gpio_HD44780_senddata;
 	p->hd44780_functions->close = gpio_HD44780_close;
 
-	if (p->have_backlight) {
+	if (have_backlight_pin(p)) {
 		if (init_gpio_pin(drvthis, &pins->bl, "BL") != 0) {
 			report(RPT_WARNING,
 			       "hd_init_gpio: unable to initialize pin_BL - disabling backlight");
-			p->have_backlight = 0;
+			set_have_backlight_pin(p, 0);
 		}
 		else {
 			p->hd44780_functions->backlight = gpio_HD44780_backlight;
@@ -256,7 +256,7 @@ gpio_HD44780_close(PrivateData *p)
 	if (p->numDisplays > 1)
 		release_gpio_pin(&pins->en2);
 
-	if (p->have_backlight)
+	if (have_backlight_pin(p))
 		release_gpio_pin(&pins->bl);
 
 	if (pins->rw)

--- a/server/drivers/hd44780-i2c.c
+++ b/server/drivers/hd44780-i2c.c
@@ -29,7 +29,7 @@
    PCF8574AP: P0 P1 P2 P3 P4 P5 P6 P7
               |  |  |  |  |  |  |  |
    HD44780:   RS RW EN BL D4 D5 D6 D7
-   
+
    in LCDd.conf we then need to define
     i2c_line_RS=0x01
     i2c_line_RW=0x02
@@ -155,7 +155,7 @@ hd_init_i2c(Driver *drvthis)
 	p->i2c_line_D5 = drvthis->config_get_int(drvthis->name, "i2c_line_D5", 0, D5);
 	p->i2c_line_D6 = drvthis->config_get_int(drvthis->name, "i2c_line_D6", 0, D6);
 	p->i2c_line_D7 = drvthis->config_get_int(drvthis->name, "i2c_line_D7", 0, D7);
-	
+
 	report(RPT_INFO, "HD44780: I2C: Init using D4 and D5, and or'd lines, invert", p->i2c_line_RS);
 	report(RPT_INFO, "HD44780: I2C: Pin RS mapped to 0x%02X", p->i2c_line_RS);
 	report(RPT_INFO, "HD44780: I2C: Pin RW mapped to 0x%02X", p->i2c_line_RW);
@@ -166,7 +166,7 @@ hd_init_i2c(Driver *drvthis)
 	report(RPT_INFO, "HD44780: I2C: Pin D6 mapped to 0x%02X", p->i2c_line_D6);
 	report(RPT_INFO, "HD44780: I2C: Pin D7 mapped to 0x%02X", p->i2c_line_D7);
 	report(RPT_INFO, "HD44780: I2C: Invert Backlight %d", p->i2c_backlight_invert);
-	
+
 	p->backlight_bit = p->i2c_line_BL;
 
 	/* READ CONFIG FILE */
@@ -249,8 +249,8 @@ hd_init_i2c(Driver *drvthis)
 	hd44780_functions->uPause(p, 100);
 
 	// Set up two-line, small character (5x8) mode
-	hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | IF_4BIT | TWOLINE | SMALLCHAR);
-	hd44780_functions->uPause(p, 40);
+	//hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | IF_4BIT | TWOLINE | SMALLCHAR);
+	//hd44780_functions->uPause(p, 40);
 
 	common_init(p, IF_4BIT);
 
@@ -318,8 +318,8 @@ i2c_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char flag
 void i2c_HD44780_backlight(PrivateData *p, unsigned char state)
 {
 	if ( p->i2c_backlight_invert == 0 )
-		p->backlight_bit = ((!p->have_backlight||state) ? 0 : p->i2c_line_BL);
+		p->backlight_bit = ((!have_backlight_pin(p)||state) ? 0 : p->i2c_line_BL);
 	else // Inverted backlight - npn transistor
-		p->backlight_bit = ((p->have_backlight && state) ? p->i2c_line_BL : 0);
+		p->backlight_bit = ((have_backlight_pin(p) && state) ? p->i2c_line_BL : 0);
 	i2c_out(p, p->backlight_bit);
 }

--- a/server/drivers/hd44780-lis2.c
+++ b/server/drivers/hd44780-lis2.c
@@ -211,7 +211,7 @@ static unsigned char rowNum = 0;
 	}
 	else {	// RS_INSTR: we have an instruction
 		if ((ch & POSITION) != 0) {
-			unsigned char divisor = (p->model == HD44780_MODEL_EXTENDED) ? 0x20 : 0x40;
+			unsigned char divisor = has_extended_mode(p) ? 0x20 : 0x40;
 
 			// get mangled position by stripping POSITION flag from given data
 			ch &= ~POSITION;

--- a/server/drivers/hd44780-lis2.c
+++ b/server/drivers/hd44780-lis2.c
@@ -211,7 +211,7 @@ static unsigned char rowNum = 0;
 	}
 	else {	// RS_INSTR: we have an instruction
 		if ((ch & POSITION) != 0) {
-			unsigned char divisor = (p->ext_mode) ? 0x20 : 0x40;
+			unsigned char divisor = (p->model == HD44780_MODEL_EXTENDED) ? 0x20 : 0x40;
 
 			// get mangled position by stripping POSITION flag from given data
 			ch &= ~POSITION;

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -126,6 +126,9 @@
 #define DEFAULT_OFFBRIGHTNESS	300
 /**@}*/
 
+/** Maximum value of brightness */
+#define MAX_BRIGHTNESS		1000
+
 /** \name Maximum sizes of the keypad
  *@{*/
 /* DO NOT CHANGE THESE VALUES, unless you change the functions too! */
@@ -277,6 +280,15 @@ typedef struct hd44780_private_data {
 	          		     set to HD44780_MODEL_EXTENDED */
 	int line_address;	/**< address of the next line in extended mode  */
 	int backlight_type;	/**< way of handling backlight. */
+	int backlight_cmd_on;	/**< internal command(s) for enabling backlight */
+	int backlight_cmd_off;	/**< internal command(s) for disabling backlight */
+
+	/** Value saved during display initialization in common_init(),
+	 *  given for FUNC_SET command, to use for later.
+	 *
+	 *  NOTE: if common_init() from specific connection type is not called,
+	 *  update it for correct value. For now used only for PT6314_VFD model */
+	int func_set_mode;
 
 	int delayMult;		/**< Delay multiplier for slow displays */
 	char delayBus;		/**< Delay if data is sent too fast over LPT port */
@@ -494,6 +506,7 @@ static void set_have_backlight_pin(PrivateData *p, int on) {
 #define WINST_PWRON	0x04	/**< Internal power on (high brightness)*/
 #define WINST_PWROFF	0x00	/**< Internal power off (low brightness)*/
 
+
 /** Function set (RE=0) */
 #define FUNCSET		0x20
 #define IF_8BIT		0x10
@@ -504,6 +517,18 @@ static void set_have_backlight_pin(PrivateData *p, int on) {
 #define SMALLCHAR	0x00	/**< 5x8 characters */
 #define EXTREG		0x04	/**< Select ext. registers (Yes, the same bits) */
 #define SEGBLINK	0x02	/**< CGRAM/SEGRAM blink, only if RE=1 */
+
+/** Extra definitions for setting PT6314_VFD brihtness
+ *  yes - same bits used as extended registers */
+#define PT6314_BRIGHT_100	0x00
+#define PT6314_BRIGHT_75	0x01
+#define PT6314_BRIGHT_50	0x02
+#define PT6314_BRIGHT_25	0x03
+
+/* mask for brightness */
+#define PT6314_BRIGHT_MASK	0x03
+
+
 
 /** Set CGRAM address (RE=0) */
 #define SETCHAR		0x40

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -97,6 +97,28 @@
 
 /** @} */
 
+/** \name Types of backlight handling
+ * @{
+ * Shall be treated as bitmask
+ */
+
+
+/** No backlight handling at all */
+#define BACKLIGHT_NONE              0
+
+/** Backlight handled hrough external pin. */
+#define BACKLIGHT_EXTERNAL_PIN 0x0001
+
+/** Backlight handled through internal commands built in driver,
+ *  usually through special commands for model chosen with Model option*/
+#define BACKLIGHT_INTERNAL     0x0002
+
+/** Backlight handled through internal commands defined in configuration file */
+#define BACKLIGHT_CONFIG_CMDS  0x0004
+
+/** @} */
+
+
 /** \name Symbolic default values
  *@{*/
 #define DEFAULT_CONTRAST	800
@@ -246,14 +268,15 @@ typedef struct hd44780_private_data {
 	/** \name Display features
 	 *@{*/
 	char have_keypad;
-	char have_backlight;
 	char have_output;
+	/* have_backlight moved to function have_backlight_pin() below */
 	/**@}*/
 
 	int model;		/**< model selected in configuration.
 	          		     For extended mode on some weird controllers
 	          		     set to HD44780_MODEL_EXTENDED */
 	int line_address;	/**< address of the next line in extended mode  */
+	int backlight_type;	/**< way of handling backlight. */
 
 	int delayMult;		/**< Delay multiplier for slow displays */
 	char delayBus;		/**< Delay if data is sent too fast over LPT port */
@@ -394,6 +417,19 @@ has_extended_mode(PrivateData *p) {
 	return p->model == HD44780_MODEL_EXTENDED;
 }
 
+/* returns if display is configured to use external backlight pin */
+static char have_backlight_pin(PrivateData *p) {
+
+	return (p->backlight_type & BACKLIGHT_EXTERNAL_PIN);
+}
+
+/* sets configration value for using external pin for backlight */
+static void set_have_backlight_pin(PrivateData *p, int on) {
+	if (on)
+		p->backlight_type |= BACKLIGHT_EXTERNAL_PIN;
+	else
+		p->backlight_type &= ~BACKLIGHT_EXTERNAL_PIN;
+}
 
 
 /* commands for senddata */

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -388,6 +388,13 @@ typedef struct hwDependentFns {
 /* Prototypes */
 void common_init(PrivateData *p, unsigned char if_bit);
 
+/* returns if display needs/is using 'Extended mode'- nonzero if yes */
+static short
+has_extended_mode(PrivateData *p) {
+	return p->model == HD44780_MODEL_EXTENDED;
+}
+
+
 
 /* commands for senddata */
 #define RS_DATA		0x00

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -129,6 +129,10 @@
 /** Maximum value of brightness */
 #define MAX_BRIGHTNESS		1000
 
+/** Maximum value of contrast */
+#define MAX_CONTRAST		1000
+
+
 /** \name Maximum sizes of the keypad
  *@{*/
 /* DO NOT CHANGE THESE VALUES, unless you change the functions too! */

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -75,6 +75,28 @@
 #define IF_TYPE_SPI		6
 /**@}*/
 
+/** \name Symbolic name for specific models
+ * @{
+ * Used here to handle various conflicting differences in command sets.
+ * Some optional features are nottied to model even if it appears only in that model
+ * unless not are not conflicting, as default settings are compatible across all devices.
+ * (for example FontBank) */
+
+/** Standard / default model. Should work with most of HD44780-compatible displays */
+#define HD44780_MODEL_DEFAULT		0
+/** Extended model - 4 lines activated with special bits and extra commands (EXTREG) */
+#define HD44780_MODEL_EXTENDED		1
+/** WINSTAR WEH00xxyyA (WEH001604A, WEH002004A, ...) and others, requires slightly different
+ * initialization sequence and have extra commands for handling brightness */
+#define HD44780_MODEL_WINSTAR_OLED	2
+/** PTC PT6314 VFD Displays - have extra command for setting four-level brightness.
+ *  Otherwise is compatible to other HD44780s */
+#define HD44780_MODEL_PT6314_VFD	3
+
+/* Possibly extended further...*/
+
+/** @} */
+
 /** \name Symbolic default values
  *@{*/
 #define DEFAULT_CONTRAST	800
@@ -162,7 +184,7 @@ typedef struct hd44780_private_data {
 
 #ifdef HAVE_I2C
 	/* i2c based connection types */
-	
+
 	int i2c_backlight_invert;
 	int i2c_line_RS;
 	int i2c_line_RW;
@@ -228,7 +250,9 @@ typedef struct hd44780_private_data {
 	char have_output;
 	/**@}*/
 
-	char ext_mode;		/**< use extended mode on some weird controllers */
+	int model;		/**< model selected in configuration.
+	          		     For extended mode on some weird controllers
+	          		     set to HD44780_MODEL_EXTENDED */
 	int line_address;	/**< address of the next line in extended mode  */
 
 	int delayMult;		/**< Delay multiplier for slow displays */
@@ -419,6 +443,13 @@ void common_init(PrivateData *p, unsigned char if_bit);
 
 /** Shift or scroll enable (RE=1) */
 #define HSCROLLEN	0x10
+
+/** Extra definitions on Winstar OLED displays - set last 2 bits (=0x03) to activate */
+#define WINST_MODESET	0x13	/**< required bits for command */
+#define WINST_TEXTMODE	0x00	/**< Activate text mode */
+#define WINST_GRAPHMODE	0x08	/**< Activate graphic mode */
+#define WINST_PWRON	0x04	/**< Internal power on (high brightness)*/
+#define WINST_PWROFF	0x00	/**< Internal power off (low brightness)*/
 
 /** Function set (RE=0) */
 #define FUNCSET		0x20

--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -315,7 +315,7 @@ send_nibble(PrivateData *p, unsigned char ch, unsigned char displayID)
 		if (displayID == 2 || (p->numDisplays > 1 && displayID == 0))
 			SET_GPIO(p->rpi_gpio->en2, 0);
 		p->hd44780_functions->uPause(p, 50);
-	}		
+	}
 }
 
 
@@ -333,7 +333,7 @@ lcdrpi_HD44780_close(PrivateData *p)
 	INP_GPIO(p->rpi_gpio->d6);
 	INP_GPIO(p->rpi_gpio->d5);
 	INP_GPIO(p->rpi_gpio->d4);
-	if (p->have_backlight)
+	if (have_backlight_pin(p))
 		INP_GPIO(p->backlight_bit);
 	if (p->numDisplays > 1)
 		INP_GPIO(p->rpi_gpio->en2);
@@ -376,12 +376,12 @@ hd_init_rpi(Driver *drvthis)
 	p->rpi_gpio->d5 = drvthis->config_get_int(drvthis->name, "pin_D5", 0, RPI_DEF_D5);
 	p->rpi_gpio->d4 = drvthis->config_get_int(drvthis->name, "pin_D4", 0, RPI_DEF_D4);
 
-	debug(RPT_INFO, "hd_init_rpi: Pin EN mapped to GPIO%d", p->rpi_gpio->en);
-	debug(RPT_INFO, "hd_init_rpi: Pin RS mapped to GPIO%d", p->rpi_gpio->rs);
-	debug(RPT_INFO, "hd_init_rpi: Pin D4 mapped to GPIO%d", p->rpi_gpio->d4);
-	debug(RPT_INFO, "hd_init_rpi: Pin D5 mapped to GPIO%d", p->rpi_gpio->d5);
-	debug(RPT_INFO, "hd_init_rpi: Pin D6 mapped to GPIO%d", p->rpi_gpio->d6);
-	debug(RPT_INFO, "hd_init_rpi: Pin D7 mapped to GPIO%d", p->rpi_gpio->d7);
+	report(RPT_INFO, "hd_init_rpi: Pin EN mapped to GPIO%d", p->rpi_gpio->en);
+	report(RPT_INFO, "hd_init_rpi: Pin RS mapped to GPIO%d", p->rpi_gpio->rs);
+	report(RPT_INFO, "hd_init_rpi: Pin D4 mapped to GPIO%d", p->rpi_gpio->d4);
+	report(RPT_INFO, "hd_init_rpi: Pin D5 mapped to GPIO%d", p->rpi_gpio->d5);
+	report(RPT_INFO, "hd_init_rpi: Pin D6 mapped to GPIO%d", p->rpi_gpio->d6);
+	report(RPT_INFO, "hd_init_rpi: Pin D7 mapped to GPIO%d", p->rpi_gpio->d7);
 
 	if (check_pin(drvthis, p->rpi_gpio->en, allowed_gpio_pins, used_pins) ||
 	    check_pin(drvthis, p->rpi_gpio->rs, allowed_gpio_pins, used_pins) ||
@@ -402,13 +402,13 @@ hd_init_rpi(Driver *drvthis)
 		}
 	}
 
-	if (p->have_backlight) {	/* Backlight setup is optional */
+	if (have_backlight_pin(p)) {	/* Backlight setup is optional */
 		p->backlight_bit = drvthis->config_get_int(drvthis->name, "pin_BL", 0, RPI_DEF_BL);
 		debug(RPT_INFO, "hd_init_rpi: Backlight mapped to GPIO%d", p->backlight_bit);
 
 		if (check_pin(drvthis, p->backlight_bit, allowed_gpio_pins, used_pins) != 0) {
 			report(RPT_WARNING, "hd_init_rpi: Invalid backlight configuration - disabling backlight");
-			p->have_backlight = 0;
+			set_have_backlight_pin(p, 0);
 		}
 	}
 
@@ -429,7 +429,7 @@ hd_init_rpi(Driver *drvthis)
 	p->hd44780_functions->senddata = lcdrpi_HD44780_senddata;
 	p->hd44780_functions->close = lcdrpi_HD44780_close;
 
-	if (p->have_backlight) {
+	if (have_backlight_pin(p)) {
 		setup_gpio(drvthis, p->backlight_bit);
 		p->hd44780_functions->backlight = lcdrpi_HD44780_backlight;
 	}

--- a/server/drivers/hd44780-serial.c
+++ b/server/drivers/hd44780-serial.c
@@ -188,7 +188,7 @@ hd_init_serial(Driver *drvthis)
 		report(RPT_ERR, "HD44780: serial: check your configuration file and disable it");
 		return -1;
 	}
-	if (p->have_backlight && !(SERIAL_IF.backlight)) {
+	if (have_backlight_pin(p) && !(SERIAL_IF.backlight)) {
 		report(RPT_ERR, "HD44780: serial: backlight control is not supported by connection type");
 		report(RPT_ERR, "HD44780: serial: check your configuration file and disable it");
 		return -1;
@@ -252,7 +252,7 @@ hd_init_serial(Driver *drvthis)
 			SERIAL_IF.pre_init);
 		p->hd44780_functions->uPause(p, 40);
 	}
-	
+
 	/* Do initialization */
 	if (SERIAL_IF.if_bits == 8) {
 		report(RPT_INFO,"HD44780: serial: initializing with 8 bits interface");
@@ -353,13 +353,13 @@ serial_HD44780_scankeypad(PrivateData *p)
 	char hangcheck = 100;
 
 	if (SERIAL_IF.keypad_command) {
-	
+
 		serial_HD44780_senddata(p, 0, RS_INSTR, SERIAL_IF.keypad_command);
 
 		if (poll(&pfd, 1, 250) != 1)
 			return 0;
 	}
-	
+
 	if (read(p->fd, &buffer, 1) == 1 && buffer == SERIAL_IF.keypad_escape) {
 		while (hangcheck > 0) {
 			/* Check if I can read another byte */
@@ -397,7 +397,7 @@ serial_HD44780_scankeypad(PrivateData *p)
 					    case 0x4E:
 					    case 0xB7:
 						return 0x44;	/* KeyMAtrix_4_4=Escape */
-					    /* No key 0x4F/0xBF or more than one key */ 
+					    /* No key 0x4F/0xBF or more than one key */
 					    default:
 						return 0;
 					}

--- a/server/drivers/hd44780-usb4all.c
+++ b/server/drivers/hd44780-usb4all.c
@@ -206,7 +206,7 @@ usb4all_init(PrivateData *p)
 	}
 
 	usb4all_init_pwm(p, USB4ALL_PWM_CONTRAST);
-	if (p->have_backlight) {
+	if (have_backlight_pin(p)) {
 		usb4all_init_pwm(p, USB4ALL_PWM_BRIGHTNESS);
 	}
 
@@ -452,7 +452,7 @@ void
 usb4all_HD44780_close(PrivateData *p)
 {
 	if (p->usbHandle != NULL) {
-		if (p->have_backlight) {
+		if (have_backlight_pin(p)) {
 			usb4all_HD44780_backlight(p, BACKLIGHT_OFF);
 		}
 

--- a/server/drivers/hd44780-uss720.c
+++ b/server/drivers/hd44780-uss720.c
@@ -223,7 +223,7 @@ uss720_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char f
 
 	if (displayID == 0)
 		enableLines = EnMask[0]
-		| ((p->have_backlight) ? 0 : EnMask[1])
+		| ((have_backlight_pin(p)) ? 0 : EnMask[1])
 		| ((p->numDisplays == 3) ? EnMask[2] : 0);
 	else
 		enableLines = EnMask[displayID - 1];

--- a/server/drivers/hd44780-winamp.c
+++ b/server/drivers/hd44780-winamp.c
@@ -109,17 +109,17 @@ hd_init_winamp(Driver *drvthis)
 
 	// Safety check against common configuration errors
 	if (p->numDisplays == 2) {
-		if (p->have_backlight && (EnMask[1] == BL)) {
+		if (have_backlight_pin(p) && (EnMask[1] == BL)) {
 			report(RPT_ERR, "hd_init_winamp: backlight must be on different pin than 2nd controller");
 			report(RPT_ERR, "hd_init_winamp: please change connection mapping in hd44780-winamp.c");
 			return -1;
 		}
-		if (p->have_backlight && p->have_output) {
+		if (have_backlight_pin(p) && p->have_output) {
 			report(RPT_ERR, "hd_init_winamp: backlight and output not possible with 2 controllers");
 			return -1;
 		}
 	}
-	else if (p->numDisplays == 3 && (p->have_backlight || p->have_output)) {
+	else if (p->numDisplays == 3 && (have_backlight_pin(p) || p->have_output)) {
 		report(RPT_ERR, "hd_init_winamp: backlight or output not possible with 3 controllers");
 		return -1;
 	}

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -253,7 +253,7 @@ static void strappend(char *dst, size_t dsize, const char *src) {
 		dst[dlen+slen] = 0;
 	}
 	else if (dlen < dsize) {
-		memcpy(dst + dlen, src, slen - (dsize - dlen));
+		memcpy(dst + dlen, src, dsize - dlen);
 		dst[dsize-1] = 0;
 	}
 }

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -121,15 +121,12 @@ static const struct ModelMapping {
 
 	{ "extended",     HD44780_MODEL_EXTENDED },
 	{ "ks0073",       HD44780_MODEL_EXTENDED },
+	{ "hd66710",      HD44780_MODEL_EXTENDED },
 
 	{ "winstar_oled", HD44780_MODEL_WINSTAR_OLED },
 	{ "weh00xxyya",   HD44780_MODEL_WINSTAR_OLED },
-	{ "winstar",      HD44780_MODEL_WINSTAR_OLED },
-	{ "winstaroled",  HD44780_MODEL_WINSTAR_OLED },
 
 	{ "pt6314_vfd",   HD44780_MODEL_PT6314_VFD },
-	{ "pt6314",       HD44780_MODEL_PT6314_VFD },
-	{ "pt6314vfd",    HD44780_MODEL_PT6314_VFD },
 
 	{ "",             HD44780_MODEL_DEFAULT }
 };
@@ -533,7 +530,7 @@ HD44780_init(Driver *drvthis)
 void
 common_init(PrivateData *p, unsigned char if_bit)
 {
-	if (p->model == HD44780_MODEL_EXTENDED) {
+	if (has_extended_mode(p)) {
 		/* Set up extended mode */
 		p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | EXTREG);
 		p->hd44780_functions->uPause(p, 40);
@@ -685,7 +682,7 @@ HD44780_position(Driver *drvthis, int x, int y)
 	int relY = y - p->dispVOffset[dispID - 1];
 	int DDaddr;
 
-	if (p->model == HD44780_MODEL_EXTENDED) {
+	if (has_extended_mode(p)) {
 		/* Linear addressing, each line starts 0x20 higher. */
 		DDaddr = x + relY * p->line_address;
 	} else {

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -473,16 +473,27 @@ common_init(PrivateData *p, unsigned char if_bit)
 		p->hd44780_functions->senddata(p, 0, RS_INSTR, EXTMODESET | FOURLINE);
 		p->hd44780_functions->uPause(p, 40);
 	}
-	p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | p->font_bank);
+	else {
+		/* set up standard mode. by default font_bank is zero (and is ignored on most of displays) */
+		p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | p->font_bank);
+		p->hd44780_functions->uPause(p, 40);
+	}
+
+	/* Turn off display, as manipulatimg below can cause some garbage on screen */
+	p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPOFF | CURSOROFF | CURSORNOBLINK);
 	p->hd44780_functions->uPause(p, 40);
-	p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPON | CURSOROFF | CURSORNOBLINK);
-	p->hd44780_functions->uPause(p, 40);
+
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, CLEAR);
 	p->hd44780_functions->uPause(p, 1600);
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, ENTRYMODE | E_MOVERIGHT | NOSCROLL);
 	p->hd44780_functions->uPause(p, 40);
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, HOMECURSOR);
 	p->hd44780_functions->uPause(p, 1600);
+
+	/* Turn on display again */
+	p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPON | CURSOROFF | CURSORNOBLINK);
+	p->hd44780_functions->uPause(p, 40);
+
 	if (p->hd44780_functions->flush != NULL)
 		p->hd44780_functions->flush(p);
 }

--- a/server/drivers/hd44780.c
+++ b/server/drivers/hd44780.c
@@ -112,6 +112,52 @@ unsigned char HD44780_scankeypad(PrivateData *p);
 static int parse_span_list(int *spanListArray[], int *spLsize, int *dispOffsets[], int *dOffsize, int *dispSizeArray[], const char *spanlist);
 
 
+static const struct ModelMapping {
+	const char *name;
+	int model;
+} model_mapping[] = {
+	{ "default",      HD44780_MODEL_DEFAULT },
+	{ "standard",     HD44780_MODEL_DEFAULT },
+
+	{ "extended",     HD44780_MODEL_EXTENDED },
+	{ "ks0073",       HD44780_MODEL_EXTENDED },
+
+	{ "winstar_oled", HD44780_MODEL_WINSTAR_OLED },
+	{ "weh00xxyya",   HD44780_MODEL_WINSTAR_OLED },
+	{ "winstar",      HD44780_MODEL_WINSTAR_OLED },
+	{ "winstaroled",  HD44780_MODEL_WINSTAR_OLED },
+
+	{ "pt6314_vfd",   HD44780_MODEL_PT6314_VFD },
+	{ "pt6314",       HD44780_MODEL_PT6314_VFD },
+	{ "pt6314vfd",    HD44780_MODEL_PT6314_VFD },
+
+	{ "",             HD44780_MODEL_DEFAULT }
+};
+
+static int model_by_name( const char *name )
+{
+	int i;
+
+	for (i=0; i<sizeof(model_mapping)/sizeof(model_mapping[0]); i++) {
+		if (strcasecmp(model_mapping[i].name, name) == 0 )
+			return model_mapping[i].model;
+	}
+
+	return -1;
+}
+
+static const char *model_name( int type )
+{
+	int i;
+
+	for (i=0; i<sizeof(model_mapping)/sizeof(model_mapping[0]); i++) {
+		if (model_mapping[i].model == type)
+			return model_mapping[i].name;
+	}
+
+	return "";
+}
+
 /**
  * Initialize the driver.
  * Initialize common part of drive & call sub-initialization
@@ -129,7 +175,7 @@ HD44780_init(Driver *drvthis)
 	int i = 0;
 	int (*init_fn) (Driver *drvthis) = NULL;
 	int if_type = IF_TYPE_UNKNOWN;
-	int tmp;
+	int tmp, ext_mode;
 	PrivateData *p;
 	char conf_charmap[MAX_CHARMAP_NAME_LENGTH];
 
@@ -153,7 +199,27 @@ HD44780_init(Driver *drvthis)
 	/* READ THE CONFIG FILE */
 
 	p->port			= drvthis->config_get_int(drvthis->name, "port", 0, LPTPORT);
-	p->ext_mode		= drvthis->config_get_bool(drvthis->name, "extendedmode", 0, 0);
+	s			= drvthis->config_get_string(drvthis->name, "model", 0, "default");
+	p->model		= model_by_name(s);
+	if (p->model < 0) {
+		report(RPT_ERR, "%s: unknown Model: %s", drvthis->name, s);
+		return -1;
+	}
+	/* config file compability stuff */
+	if (p->model == HD44780_MODEL_DEFAULT) {
+		ext_mode	= drvthis->config_get_bool(drvthis->name, "extendedmode", 0, 0);
+		if (ext_mode)
+			p->model = HD44780_MODEL_EXTENDED;
+	}
+	else {
+		tmp = (p->model == HD44780_MODEL_EXTENDED);
+		ext_mode = !!drvthis->config_get_bool(drvthis->name, "extendedmode", 0, tmp);
+		if (ext_mode != tmp) {
+			report(RPT_ERR, "%s: conflicting Model %s and extended mode: %d", drvthis->name, model_name(p->model), ext_mode);
+			return -1;
+		}
+	}
+
 	p->line_address 	= drvthis->config_get_int(drvthis->name, "lineaddress", 0, LADDR);
 	p->have_keypad		= drvthis->config_get_bool(drvthis->name, "keypad", 0, 0);
 	p->have_backlight	= drvthis->config_get_bool(drvthis->name, "backlight", 0, 0);
@@ -184,6 +250,7 @@ HD44780_init(Driver *drvthis)
 		if_type = connectionMapping[i].if_type;
 		init_fn = connectionMapping[i].init_fn;
 	}
+	report(RPT_INFO, "HD44780: selecting Model: %s", model_name(p->model));
 
 	/* Get and parse vspan only when specified */
 	s = drvthis->config_get_string(drvthis->name, "vspan", 0, "");
@@ -466,25 +533,37 @@ HD44780_init(Driver *drvthis)
 void
 common_init(PrivateData *p, unsigned char if_bit)
 {
-	if (p->ext_mode) {
+	if (p->model == HD44780_MODEL_EXTENDED) {
 		/* Set up extended mode */
 		p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | EXTREG);
 		p->hd44780_functions->uPause(p, 40);
 		p->hd44780_functions->senddata(p, 0, RS_INSTR, EXTMODESET | FOURLINE);
 		p->hd44780_functions->uPause(p, 40);
 	}
-	else {
-		/* set up standard mode. by default font_bank is zero (and is ignored on most of displays) */
-		p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | p->font_bank);
-		p->hd44780_functions->uPause(p, 40);
-	}
+
+	/* set up standard mode. by default font_bank is zero (and is ignored on most of displays) */
+	p->hd44780_functions->senddata(p, 0, RS_INSTR, FUNCSET | if_bit | TWOLINE | SMALLCHAR | p->font_bank);
+	p->hd44780_functions->uPause(p, 40);
 
 	/* Turn off display, as manipulatimg below can cause some garbage on screen */
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, ONOFFCTRL | DISPOFF | CURSOROFF | CURSORNOBLINK);
 	p->hd44780_functions->uPause(p, 40);
 
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, CLEAR);
-	p->hd44780_functions->uPause(p, 1600);
+	/* winstar OLEDs require 6.2ms for this command, according to spec */
+	p->hd44780_functions->uPause(p, (p->model == HD44780_MODEL_WINSTAR_OLED) ? 6200 : 1600);
+
+	if (p->model == HD44780_MODEL_WINSTAR_OLED) {
+		/* For WINSTAR OLED displays need to set TEXT mode and additionally level of brigtness.
+		 * It is particularly important on reinitialization without powering off it first */
+		unsigned char pwr = WINST_PWROFF;
+		if (p->brightness >= 500) {
+			pwr = WINST_PWRON;
+		}
+		p->hd44780_functions->senddata(p, 0, RS_INSTR, WINST_MODESET | WINST_TEXTMODE | pwr);
+		p->hd44780_functions->uPause(p, 500);
+	}
+
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, ENTRYMODE | E_MOVERIGHT | NOSCROLL);
 	p->hd44780_functions->uPause(p, 40);
 	p->hd44780_functions->senddata(p, 0, RS_INSTR, HOMECURSOR);
@@ -606,7 +685,7 @@ HD44780_position(Driver *drvthis, int x, int y)
 	int relY = y - p->dispVOffset[dispID - 1];
 	int DDaddr;
 
-	if (p->ext_mode) {
+	if (p->model == HD44780_MODEL_EXTENDED) {
 		/* Linear addressing, each line starts 0x20 higher. */
 		DDaddr = x + relY * p->line_address;
 	} else {


### PR DESCRIPTION
Added support for WINSTAR OLED displays - almost compatible to
HD44780 LCDs. These displays require slightly different initialization sequence,
especially required on display reinitialization without powering it off first.

This was achieved through additional Model option, incorporating to it 
existing 'ExtendedMode' for KS0073 display which require also special
handling. Added also PT6314 VFD model to available models.

Tested on Raspberry PI and WINSTAR WEH001604ALPP5N00001 OLED display
connected through I2C PCF8574 connection (4-bits obviously) and
WINSTAR WEH002004ALPP5N00001 OLED. Should work on any connection.

It is first part - next would be adding backlight handling using internal brightness commands for WINSTAR OLED and PT6314 VFD.