### PR TITLE
HD44780 FTDI support for USB description and serial number filtering.

### DIFF
--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -4042,13 +4042,25 @@ This can be done by specifying <option>--enable-drivers=all</option> or by inclu
 
 <varlistentry>
   <term>
+    <property>UsbDescription</property> =
+    <parameter><replaceable>DESCRIPTION</replaceable></parameter>
+  </term>
+  <listitem><para>
+    USB Description string to look for in FTDI connection types.  If not given,
+    the first USB device will be used.  If given, the first matching device
+    will be used.
+  </para></listitem>
+</varlistentry>
+
+<varlistentry>
+  <term>
     <property>SerialNumber</property> =
     <parameter><replaceable>SERIALNO</replaceable></parameter>
   </term>
   <listitem><para>
     Serial number of the USB device to look for with
-    connection type <code>bwctusb</code>.
-    If not given, the first BWCT USB module found will be used.
+    <code>bwctusb</code> and <code>FTDI</code> connection types.
+    If not given, the first BWCT/FTDI USB device found will be used.
   </para></listitem>
 </varlistentry>
 </variablelist>

--- a/server/drivers/hd44780-ftdi.c
+++ b/server/drivers/hd44780-ftdi.c
@@ -81,12 +81,10 @@ hd_init_ftdi(Driver *drvthis)
     vendor_id = drvthis->config_get_int(drvthis->name, "VendorID", 0, 0x0403);
     product_id = drvthis->config_get_int(drvthis->name, "ProductID", 0, 0x6001);
     if ((s = drvthis->config_get_string(drvthis->name, "UsbDescription", 0, NULL)) != NULL) {
-        usb_description = malloc(sizeof (char) * strlen(s) + 1);
-        strcpy(usb_description, s);
+        usb_description = strdup(s);
     }
     if ((s = drvthis->config_get_string(drvthis->name, "SerialNumber", 0, NULL)) != NULL) {
-        serial_number = malloc(sizeof (char) * strlen(s) + 1);
-        strcpy(serial_number, s);
+        serial_number = strdup(s);
     }
 
     /* these config settings are not documented intentionally */


### PR DESCRIPTION
New string configuration directive "UsbDescription" will filter for
the first USB device that has a matching USB description.  Config
"SerialNumber" same convention as from BWCT driver.  Both unconfigured
retains same behaviour as before.

We use FTDI interfaces for a lot of hardware projects, and without this patch it is very tricky to get LCDd to open the correct one!