### PR TITLE
Added option to omit hostname in title bar

### DIFF
--- a/clients/lcdproc/batt.c
+++ b/clients/lcdproc/batt.c
@@ -110,7 +110,7 @@ battery_screen(int rep, int display, int *flags_ptr)
 		*flags_ptr |= INITIALIZED;
 
 		sock_send_string(sock, "screen_add B\n");
-		sock_printf(sock, "screen_set B -name {APM stats: %s}\n", get_hostname());
+		sock_printf(sock, "screen_set B -name {APM stats:%s}\n", get_hostname());
 		sock_send_string(sock, "widget_add B title title\n");
 		sock_printf(sock, "widget_set B title {LCDPROC %s}\n", version);
 		sock_send_string(sock, "widget_add B one string\n");
@@ -135,7 +135,7 @@ battery_screen(int rep, int display, int *flags_ptr)
 			sprintf(tmp, "%d%%", percent);
 		else
 			sprintf(tmp, "??%%");
-		sock_printf(sock, "widget_set B title {%s: %s: %s}\n",
+		sock_printf(sock, "widget_set B title {%s: %s:%s}\n",
 				(acstat == LCDP_AC_ON && battstat == LCDP_BATT_ABSENT) ? "AC" : "Batt",
 				tmp, get_hostname());
 
@@ -155,4 +155,3 @@ battery_screen(int rep, int display, int *flags_ptr)
 
 	return 0;
 }
-

--- a/clients/lcdproc/chrono.c
+++ b/clients/lcdproc/chrono.c
@@ -98,12 +98,12 @@ time_screen(int rep, int display, int *flags_ptr)
 			sock_send_string(sock, "widget_add T three string\n");
 
 			/* write title bar: OS name, OS version, hostname */
-			sock_printf(sock, "widget_set T title {%s %s: %s}\n",
+			sock_printf(sock, "widget_set T title {%s %s:%s}\n",
 				get_sysname(), get_sysrelease(), get_hostname());
 		}
 		else {
 			/* write title bar: hostname */
-			sock_printf(sock, "widget_set T title {TIME: %s}\n", get_hostname());
+			sock_printf(sock, "widget_set T title {TIME:%s}\n", get_hostname());
 		}
 	}
 
@@ -375,9 +375,9 @@ uptime_screen(int rep, int display, int *flags_ptr)
  * |                    |
  * +--------------------+
  *
- * Alternate version without seconds : 
+ * Alternate version without seconds :
  *
- * +--------------------+ 
+ * +--------------------+
  * |       _   _        |
  * |     ||_ . _||_|    |
  * |     ||_|. _|  |    |
@@ -540,4 +540,3 @@ tickTime(char *time, int heartbeat)
 	}
 	return (time);
 }
-

--- a/clients/lcdproc/cpu.c
+++ b/clients/lcdproc/cpu.c
@@ -65,7 +65,7 @@ cpu_screen(int rep, int display, int *flags_ptr)
 		*flags_ptr |= INITIALIZED;
 
 		sock_send_string(sock, "screen_add C\n");
-		sock_printf(sock, "screen_set C -name {CPU Use: %s}\n", get_hostname());
+		sock_printf(sock, "screen_set C -name {CPU Use:%s}\n", get_hostname());
 		if (lcd_hgt >= 4) {
 			gauge_wid = lcd_wid - 6;	/* room between 0%...100% */
 
@@ -145,7 +145,7 @@ cpu_screen(int rep, int display, int *flags_ptr)
 
 	if (lcd_hgt >= 4) {	/* 4-line display */
 		sprintf_percent(tmp, cpu[CPU_BUF_SIZE][4]);
-		sock_printf(sock, "widget_set C title {CPU %5s: %s}\n", tmp, get_hostname());
+		sock_printf(sock, "widget_set C title {CPU %5s:%s}\n", tmp, get_hostname());
 
 		sprintf_percent(tmp, cpu[CPU_BUF_SIZE][0]);
 		sock_printf(sock, "widget_set C usr %i 2 {%5s}\n", (lcd_wid / 2) - 5, tmp);
@@ -225,15 +225,15 @@ cpu_graph_screen(int rep, int display, int *flags_ptr)
 		gauge_hgt = (lcd_hgt > 2) ? (lcd_hgt - 1) : lcd_hgt;
 
 		sock_send_string(sock, "screen_add G\n");
-		sock_printf(sock, "screen_set G -name {CPU Graph: %s}\n", get_hostname());
+		sock_printf(sock, "screen_set G -name {CPU Graph:%s}\n", get_hostname());
 
 		if (lcd_hgt >= 4) {
 			sock_send_string(sock, "widget_add G title title\n");
-			sock_printf(sock, "widget_set G title {CPU: %s}\n", get_hostname());
+			sock_printf(sock, "widget_set G title {CPU:%s}\n", get_hostname());
 		}
 		else {
 			sock_send_string(sock, "widget_add G title string\n");
-			sock_printf(sock, "widget_set G title 1 1 {CPU: %s}\n", get_hostname());
+			sock_printf(sock, "widget_set G title 1 1 {CPU:%s}\n", get_hostname());
 		}
 
 		for (i = 1; i <= lcd_wid; i++) {

--- a/clients/lcdproc/cpu_smp.c
+++ b/clients/lcdproc/cpu_smp.c
@@ -81,7 +81,7 @@ cpu_smp_screen (int rep, int display, int *flags_ptr)
 		/* print title if he have room for it */
 		if (lines_used < lcd_hgt) {
 			sock_send_string(sock, "widget_add P title title\n");
-			sock_printf(sock, "widget_set P title {SMP CPU %s}\n", get_hostname());
+			sock_printf(sock, "widget_set P title {SMP CPU%s}\n", get_hostname());
 		}
 		else {
 			sock_send_string(sock, "screen_set P -heartbeat off\n");

--- a/clients/lcdproc/disk.c
+++ b/clients/lcdproc/disk.c
@@ -79,7 +79,7 @@ disk_screen(int rep, int display, int *flags_ptr)
 		sock_send_string(sock, "screen_add D\n");
 		sock_printf(sock, "screen_set D -name {Disk Use: %s}\n", get_hostname());
 		sock_send_string(sock, "widget_add D title title\n");
-		sock_printf(sock, "widget_set D title {DISKS: %s}\n", get_hostname());
+		sock_printf(sock, "widget_set D title {DISKS:%s}\n", get_hostname());
 		sock_send_string(sock, "widget_add D f frame\n");
 		sock_printf(sock, "widget_set D f 1 2 %i %i %i %i v 12\n", lcd_wid, lcd_hgt, lcd_wid, lcd_hgt - 1);
 		sock_send_string(sock, "widget_add D err1 string\n");

--- a/clients/lcdproc/load.c
+++ b/clients/lcdproc/load.c
@@ -122,7 +122,7 @@ xload_screen(int rep, int display, int *flags_ptr)
 
 	/* And now the title... */
 	if (lcd_hgt > 2)
-		sock_printf(sock, "widget_set L title {LOAD %2.2f: %s}\n", loads[lcd_wid - 2], get_hostname());
+		sock_printf(sock, "widget_set L title {LOAD %2.2f:%s}\n", loads[lcd_wid - 2], get_hostname());
 	else
 		sock_printf(sock, "widget_set L title 1 1 {%s %2.2f}\n", get_hostname(), loads[lcd_wid - 2]);
 

--- a/clients/lcdproc/main.c
+++ b/clients/lcdproc/main.c
@@ -126,12 +126,14 @@ char *configfile = NULL;
 char *pidfile = NULL;
 int pidfile_written = FALSE;
 char *displayname = NULL;	/**< display name for the main menu */
+int showhostname = TRUE;
+char *hostname = NULL;
 
 /** Returns the network name of this machine */
 const char *
 get_hostname(void)
 {
-	return (unamebuf.nodename);
+	return hostname;
 }
 
 /** Returns the name of the client's OS */
@@ -217,7 +219,7 @@ main(int argc, char **argv)
 	opterr = 0;
 
 	/* get options from command line */
-	while ((c = getopt(argc, argv, "s:p:e:c:fhv")) > 0) {
+	while ((c = getopt(argc, argv, "s:p:e:c:fkhv")) > 0) {
 		char *end;
 
 		switch (c) {
@@ -269,6 +271,16 @@ main(int argc, char **argv)
 	if (cfgresult < 0) {
 		fprintf(stderr, "Error reading config file\n");
 		exit(EXIT_FAILURE);
+	}
+	if (showhostname == TRUE)
+	{
+		hostname = malloc(strlen(unamebuf.nodename)+2);
+		hostname[0] = ' ';
+		strcpy(hostname+1,unamebuf.nodename);
+	}
+	else
+	{
+		hostname = strdup("");
 	}
 
 	/* Set default reporting options */
@@ -422,9 +434,12 @@ process_configfile(char *configfile)
 	if (islow < 0) {
 		islow = config_get_int(progname, "Delay", 0, -1);
 	}
-
-	if ((tmp = config_get_string(progname, "DisplayName", 0, NULL)) != NULL)
+	if ((tmp = config_get_string(progname, "DisplayName", 0, NULL)) != NULL) {
 		displayname = strdup(tmp);
+	}
+	if (showhostname != FALSE) {
+		showhostname = config_get_bool(progname, "ShowHostname", 0, TRUE);
+	}
 
 	/*
 	 * check for config file variables to override all the sequence
@@ -499,6 +514,7 @@ exit_program(int val)
 	 */
 	eyebox_clear();
 #endif
+	free(hostname);
 	Quit = 1;
 	sock_close(sock);
 	mode_close();

--- a/clients/lcdproc/mem.c
+++ b/clients/lcdproc/mem.c
@@ -117,8 +117,11 @@ mem_screen(int rep, int display, int *flags_ptr)
 
 		/* flip the title back and forth... (every 4 updates) */
 		if (which_title & 4) {
-			sock_printf(sock, "widget_set M subtitle %i 1 {}\n", lcd_wid - 7);
-			sock_printf(sock, "widget_set M title {%s}\n", get_hostname());
+			if (get_hostname()[0] != '\0')
+			{
+				sock_printf(sock, "widget_set M subtitle %i 1 {}\n", lcd_wid - 7);
+				sock_printf(sock, "widget_set M title {%s}\n", get_hostname());
+			}
 		}
 		else {
 			sock_send_string(sock, "widget_set M title { MEM}\n");
@@ -272,7 +275,7 @@ mem_top_screen(int rep, int display, int *flags_ptr)
 		sock_send_string(sock, "screen_add S\n");
 		sock_printf(sock, "screen_set S -name {Top Memory Use: %s}\n", get_hostname());
 		sock_send_string(sock, "widget_add S title title\n");
-		sock_printf(sock, "widget_set S title {TOP MEM: %s}\n", get_hostname());
+		sock_printf(sock, "widget_set S title {TOP MEM:%s}\n", get_hostname());
 
 		/* frame from (2nd line, left) to (last line, right) */
 		sock_send_string(sock, "widget_add S f frame\n");
@@ -343,4 +346,3 @@ mem_top_screen(int rep, int display, int *flags_ptr)
 
 	return 0;
 }
-

--- a/docs/lcdproc-config.5.in
+++ b/docs/lcdproc-config.5.in
@@ -90,6 +90,11 @@ slow down initial announcement of modes (in 1/100s) [default: 2]
 .RS 4
 display name for the main menu [default: LCDproc HOST]
 .RE
+.PP
+\fIShowHostname=\fR
+.RS 4
+Show hostname in title of screen [default: true; legal: true, false]
+.RE
 
 .SH SCREEN SPECIFIC CONFIGURATION
 the following section of the \fI@SYSCONFDIR@/lcdproc.conf\fP contains screen specific configuration options. Each section refers to a screen which can be enabled and configured.


### PR DESCRIPTION
I have 20x4 display and i don't like scrolling title bar in each screen of lcdproc just to show my hostname.
So i propose this patch to add ability to control user whenever he want's hostname in title or not.