### PR TITLE
lcdproc-user: drop linux_input, since it got removed

### DIFF
--- a/docs/lcdproc-user/drivers.docbook
+++ b/docs/lcdproc-user/drivers.docbook
@@ -31,7 +31,6 @@ well as the configuration of LCDd.
 &lb216;
 &lcdm001;
 &lcterm;
-&linux_input;
 &lirc;
 &lis;
 &MD8800;

--- a/docs/lcdproc-user/lcdproc-user.docbook
+++ b/docs/lcdproc-user/lcdproc-user.docbook
@@ -38,7 +38,6 @@
   <!ENTITY lb216 SYSTEM "drivers/lb216.docbook">
   <!ENTITY lcdm001 SYSTEM "drivers/lcdm001.docbook">
   <!ENTITY lcterm SYSTEM "drivers/lcterm.docbook">
-  <!ENTITY linux_input SYSTEM "drivers/linux_input.docbook">
   <!ENTITY lirc SYSTEM "drivers/lircin.docbook">
   <!ENTITY lis SYSTEM "drivers/lis.docbook">
   <!ENTITY MD8800 SYSTEM "drivers/MD8800.docbook">


### PR DESCRIPTION
The generation of lcdproc-user will otherwise currently fail.

```
/home/conikost/lcdproc-0.5.9/docs/lcdproc-user/drivers.docbook:34: parser error : Failure to process entity linux_input
&linux_input;
             ^
/home/conikost/lcdproc-0.5.9/docs/lcdproc-user/drivers.docbook:34: parser error : Entity 'linux_input' not defined
&linux_input;
             ^
/home/conikost/lcdproc-0.5.9/docs/lcdproc-user/drivers.docbook:69: parser error : chunk is not well balanced

^
/home/conikost/lcdproc-0.5.9/docs/lcdproc-user/lcdproc-user.docbook:85: parser error : Failure to process entity drivers
&drivers;
         ^
/home/conikost/lcdproc-0.5.9/docs/lcdproc-user/lcdproc-user.docbook:85: parser error : Entity 'drivers' not defined
&drivers;
```