### PR TITLE
Small screen and mx5000 fixes

### DIFF
--- a/clients/lcdproc/cpu.c
+++ b/clients/lcdproc/cpu.c
@@ -75,9 +75,9 @@ cpu_screen(int rep, int display, int *flags_ptr)
 			sock_send_string(sock, "widget_add C two string\n");
 			sock_send_string(sock, "widget_add C three string\n");
 			sock_printf(sock, "widget_set C one 1 2 {%-*s%-*s}\n",
-					lcd_wid / 2, "Usr", lcd_wid / 2, "Nice");
+					(lcd_wid + 1) / 2, "Usr", lcd_wid / 2, "Nice");
 			sock_printf(sock, "widget_set C two 1 3 {%-*s%-*s}\n",
-					lcd_wid / 2, "Sys", lcd_wid / 2, "Idle");
+					(lcd_wid + 1) / 2, "Sys", lcd_wid / 2, "Idle");
 			sock_printf(sock, "widget_set C three 1 4 {0%%%*s100%%}\n", gauge_wid, "");
 			sock_send_string(sock, "widget_add C usr string\n");
 			sock_send_string(sock, "widget_add C nice string\n");
@@ -148,10 +148,10 @@ cpu_screen(int rep, int display, int *flags_ptr)
 		sock_printf(sock, "widget_set C title {CPU %5s: %s}\n", tmp, get_hostname());
 
 		sprintf_percent(tmp, cpu[CPU_BUF_SIZE][0]);
-		sock_printf(sock, "widget_set C usr %i 2 {%5s}\n", (lcd_wid / 2) - 5, tmp);
+		sock_printf(sock, "widget_set C usr %i 2 {%5s}\n", ((lcd_wid + 1) / 2) - 5, tmp);
 
 		sprintf_percent(tmp, cpu[CPU_BUF_SIZE][1]);
-		sock_printf(sock, "widget_set C sys %i 3 {%5s}\n", (lcd_wid / 2) - 5, tmp);
+		sock_printf(sock, "widget_set C sys %i 3 {%5s}\n", ((lcd_wid + 1) / 2) - 5, tmp);
 
 		sprintf_percent(tmp, cpu[CPU_BUF_SIZE][2]);
 		sock_printf(sock, "widget_set C nice %i 2 {%5s}\n", lcd_wid - 4, tmp);

--- a/clients/lcdproc/cpu.c
+++ b/clients/lcdproc/cpu.c
@@ -55,6 +55,8 @@ cpu_screen(int rep, int display, int *flags_ptr)
 	static double cpu[CPU_BUF_SIZE + 1][5];	/* last buffer is scratch */
 	static int gauge_wid = 0;
 	static int usni_wid = 0;
+	static int us_wid = 0;
+	static int ni_wid = 0;
 
 	int i, j, n;
 	double value;
@@ -68,16 +70,18 @@ cpu_screen(int rep, int display, int *flags_ptr)
 		sock_printf(sock, "screen_set C -name {CPU Use: %s}\n", get_hostname());
 		if (lcd_hgt >= 4) {
 			gauge_wid = lcd_wid - 6;	/* room between 0%...100% */
+			us_wid = ((lcd_wid + 1) / 2) - 7; /* Usr/Sys label width -7 for " xx.x% " */
+			ni_wid = lcd_wid / 2 - 6;       /* Nice/Idle label width -6 for " xx.x%" */
 
 			sock_send_string(sock, "widget_add C title title\n");
 			sock_send_string(sock, "widget_set C title {CPU LOAD}\n");
 			sock_send_string(sock, "widget_add C one string\n");
 			sock_send_string(sock, "widget_add C two string\n");
 			sock_send_string(sock, "widget_add C three string\n");
-			sock_printf(sock, "widget_set C one 1 2 {%-*s%-*s}\n",
-					(lcd_wid + 1) / 2, "Usr", lcd_wid / 2, "Nice");
-			sock_printf(sock, "widget_set C two 1 3 {%-*s%-*s}\n",
-					(lcd_wid + 1) / 2, "Sys", lcd_wid / 2, "Idle");
+			sock_printf(sock, "widget_set C one 1 2 {%-*.*s       %-*.*s}\n",
+					us_wid, us_wid, "Usr", ni_wid, ni_wid, "Nice");
+			sock_printf(sock, "widget_set C two 1 3 {%-*.*s       %-*.*s}\n",
+					us_wid, us_wid, "Sys", ni_wid, ni_wid, "Idle");
 			sock_printf(sock, "widget_set C three 1 4 {0%%%*s100%%}\n", gauge_wid, "");
 			sock_send_string(sock, "widget_add C usr string\n");
 			sock_send_string(sock, "widget_add C nice string\n");

--- a/clients/lcdproc/mem.c
+++ b/clients/lcdproc/mem.c
@@ -56,6 +56,7 @@ mem_screen(int rep, int display, int *flags_ptr)
 	static int gauge_wid = 0;
 	static int gauge_offs = 0;
 	static int title_sep_wid = 0;
+	int label_wid, label_offs;
 	meminfo_type mem[2];
 
 	if ((*flags_ptr & INITIALIZED) == 0) {
@@ -71,12 +72,15 @@ mem_screen(int rep, int display, int *flags_ptr)
 				    ? (lcd_wid - 6) / 2		/* room for E..F pairs and 2 spaces in between */
 				    : (lcd_wid - 4) / 2;	/* leave room for the  E...F pairs */
 
+			label_wid = (title_sep_wid >= 4) ? 4 : title_sep_wid;
+			label_offs = (lcd_wid - label_wid) / 2 + 1;
+
 			sock_send_string(sock, "widget_add M title title\n");
 			sock_printf(sock, "widget_set M title { MEM %.*s SWAP}\n", title_sep_wid, title_sep);
 			sock_send_string(sock, "widget_add M totl string\n");
-			sock_send_string(sock, "widget_add M used string\n");
-			sock_printf(sock, "widget_set M totl %i 2 Totl\n", lcd_wid/2 - 1);
-			sock_printf(sock, "widget_set M used %i 3 Free\n", lcd_wid/2 - 1);
+			sock_send_string(sock, "widget_add M free string\n");
+			sock_printf(sock, "widget_set M totl %i 2 %.*s\n", label_offs, label_wid, "Totl");
+			sock_printf(sock, "widget_set M free %i 3 %.*s\n", label_offs, label_wid, "Free");
 			sock_send_string(sock, "widget_add M EFmem string\n");
 			sock_printf(sock, "widget_set M EFmem 1 4 {E%*sF}\n", gauge_wid, "");
 			sock_send_string(sock, "widget_add M EFswap string\n");

--- a/clients/lcdproc/mem.c
+++ b/clients/lcdproc/mem.c
@@ -51,9 +51,11 @@
 int
 mem_screen(int rep, int display, int *flags_ptr)
 {
+	const char *title_sep = "####################################################################################################";
 	static int which_title = 0;
 	static int gauge_wid = 0;
 	static int gauge_offs = 0;
+	static int title_sep_wid = 0;
 	meminfo_type mem[2];
 
 	if ((*flags_ptr & INITIALIZED) == 0) {
@@ -62,15 +64,15 @@ mem_screen(int rep, int display, int *flags_ptr)
 		sock_send_string(sock, "screen_add M\n");
 		sock_printf(sock, "screen_set M -name {Memory & Swap: %s}\n", get_hostname());
 
+		title_sep_wid = (lcd_wid >= 16) ? lcd_wid - 16 : 0;
+
 		if (lcd_hgt >= 4) {
 			gauge_wid = (lcd_wid >= 18)
 				    ? (lcd_wid - 6) / 2		/* room for E..F pairs and 2 spaces in between */
 				    : (lcd_wid - 4) / 2;	/* leave room for the  E...F pairs */
 
 			sock_send_string(sock, "widget_add M title title\n");
-			sock_send_string(sock, "widget_set M title { MEM}\n");
-			sock_send_string(sock, "widget_add M subtitle string\n");
-			sock_printf(sock, "widget_set M subtitle %i 1 { SWAP }\n", lcd_wid - 6);
+			sock_printf(sock, "widget_set M title { MEM %.*s SWAP}\n", title_sep_wid, title_sep);
 			sock_send_string(sock, "widget_add M totl string\n");
 			sock_send_string(sock, "widget_add M used string\n");
 			sock_printf(sock, "widget_set M totl %i 2 Totl\n", lcd_wid/2 - 1);
@@ -116,14 +118,10 @@ mem_screen(int rep, int display, int *flags_ptr)
 		char tmp[12];	/* should be sufficient */
 
 		/* flip the title back and forth... (every 4 updates) */
-		if (which_title & 4) {
-			sock_printf(sock, "widget_set M subtitle %i 1 {}\n", lcd_wid - 7);
+		if (which_title & 4)
 			sock_printf(sock, "widget_set M title {%s}\n", get_hostname());
-		}
-		else {
-			sock_send_string(sock, "widget_set M title { MEM}\n");
-			sock_printf(sock, "widget_set M subtitle %i 1 { SWAP }\n", lcd_wid - 7);
-		}
+		else
+			sock_printf(sock, "widget_set M title { MEM %.*s SWAP}\n", title_sep_wid, title_sep);
 		which_title = (which_title + 1) & 7;
 
 		/* Total memory */

--- a/clients/lcdproc/util.c
+++ b/clients/lcdproc/util.c
@@ -37,9 +37,9 @@ sprintf_memory(char *dst, double value, double roundlimit)
 
 		char *unit = convert_double(&value, 1024, roundlimit);
 
-		if (value < 100)
+		if (value <= 99.994999999)
 			format = "%.2f%s";
-		if (value < 10)
+		if (value <= 9.9994999999)
 			format = "%.3f%s";
 
 		sprintf(dst, format, value, unit);

--- a/server/drivers/mx5000.c
+++ b/server/drivers/mx5000.c
@@ -31,11 +31,16 @@
  *
  */
 
+#include <dirent.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <linux/input.h>
 #include <libmx5000/mx5000.h>
 #include <libmx5000/mx5000screencontent.h>
 
@@ -49,6 +54,45 @@
 
 
 /* Internal functions */
+
+/* Get optional input FD for the menu buttons */
+static int
+mx5000_get_input_fd (void)
+{
+    struct input_id input_id;
+    char devname[PATH_MAX];
+    struct dirent *dirent;
+    DIR *dir;
+    int err, fd;
+
+    dir = opendir("/dev/input");
+    if (!dir)
+        return -1;
+
+    while((dirent = readdir(dir)) != NULL) {
+        if (dirent->d_type != DT_CHR ||
+            strncmp(dirent->d_name, "event", 5))
+                continue;
+
+        strcpy(devname, "/dev/input/");
+        strcat(devname, dirent->d_name);
+
+        fd = open(devname, O_RDONLY | O_NONBLOCK);
+        if (fd == -1)
+            continue;
+
+        err = ioctl(fd, EVIOCGID, &input_id);
+        if (err == 0 && input_id.vendor == 0x046d && input_id.product == 0xb305)
+        {
+            report(RPT_DEBUG, "mx5000: Reading input events from %s", devname);
+            return fd;
+        }
+
+        close(fd);
+    }
+
+    return -1;
+}
 
 /*
  * Prepare a static screen
@@ -93,6 +137,8 @@ mx5000_init (Driver *drvthis, char *args)
                 drvthis->name, strerror(errno));
         return -1;
     }
+
+    p->input_fd = mx5000_get_input_fd();
 
     report(RPT_DEBUG, "%s: init() done", drvthis->name);
 
@@ -403,4 +449,74 @@ mx5000_get_info (Driver *drvthis)
     strcpy(p->info, "Logitech MX 5000 Driver");
 
     return p->info;
+}
+
+/*
+ * Map scancodes for the buttons below the LCD to the default [menu]
+ * config key strings for the example LCDd.conf .
+ */
+static const char *
+mx5000_translate_scancode(int scan_code)
+{
+    const char *key_name = NULL;
+
+    switch (scan_code) {
+    case 0xc100c:
+        /* Most left key below the LCD, we use this to enter/exit the menu */
+	key_name = "Escape";
+	break;
+    case 0xc100d:
+        /* Most right key below the LCD, we use this to select menu items */
+	key_name = "Enter";
+	break;
+    case 0xc100e:
+        /* Left button of the 2 middle buttons, marked with an arrow pointing up */
+	key_name = "Up";
+	break;
+    case 0xc100f:
+        /* Right button of the 2 middle buttons, marked with an arrow pointing down */
+	key_name = "Down";
+	break;
+    }
+
+    if (key_name)
+        report(RPT_DEBUG, "mx5000_get_key detected %s key-press", key_name);
+
+    return key_name;
+}
+
+/**
+ * Read the next input event.
+ * \param drvthis  Pointer to driver structure.
+ * \retval         String representation of the key;
+ *                 \c NULL for nothing available / error.
+ */
+MODULE_EXPORT const char *
+mx5000_get_key (Driver *drvthis)
+{
+    PrivateData *p = drvthis->private_data;
+    struct input_event event;
+    int scan_code = 0;
+    int value = 0;
+
+    while (read(p->input_fd, &event, sizeof(event)) == sizeof(event)) {
+	switch (event.type) {
+	case EV_SYN:
+	    /* If we got a keypress return the scancode translated to a string */
+	    if (scan_code && value)
+                return mx5000_translate_scancode(scan_code);
+            /* Reset */
+            scan_code = 0;
+            value = 0;
+            break;
+        case EV_KEY:
+            value = event.value;
+            break;
+        case EV_MSC:
+            if (event.code == MSC_SCAN)
+                scan_code = event.value;
+            break;
+	}
+    }
+    return NULL;
 }

--- a/server/drivers/mx5000.c
+++ b/server/drivers/mx5000.c
@@ -276,7 +276,7 @@ mx5000_hbar (Driver *drvthis, int x, int y, int len, int promille, int options)
     py = y * CELL_HEIGHT;
 
     mx5000_sc_add_progress_bar(p->sc,
-			       promille * len / 1000,
+			       (promille * len + 500) / 1000,
 			       len,
 			       STATIC,
 			       py,

--- a/server/drivers/mx5000.c
+++ b/server/drivers/mx5000.c
@@ -289,7 +289,7 @@ mx5000_num (Driver *drvthis, int x, int num)
 {
     PrivateData *p = drvthis->private_data;
     int px, py;
-    char text[10];
+    char text[12];
     px = (x - 1) * CELL_WIDTH;
     py = 33;
 

--- a/server/drivers/mx5000.h
+++ b/server/drivers/mx5000.h
@@ -35,6 +35,7 @@ typedef struct mx5000_private_data {
     char device[200];
     int wait;
     int fd;
+    int input_fd;
     struct MX5000ScreenContent *sc;
     char info[255];
     char changed;


### PR DESCRIPTION
Here is a series of fixes for screens with 4+ lines, while being smaller then 18 characters wide as well as a some fixes + input support for the mx5000 driver.

This series has been tested with a mx5000 keyboard which has a builtin LCD with a size of 17x4 characters.