### PR TITLE
Bar widgets rework

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,7 +246,7 @@ AC_ARG_WITH(lcdport,
 )
 AC_DEFINE_UNQUOTED(LCDPORT, $LCDPORT, [Set default port where LCDd should listen])
 
-AC_DEFINE_UNQUOTED(PROTOCOL_VERSION, "0.3", [Define version of lcdproc client-server protocol])
+AC_DEFINE_UNQUOTED(PROTOCOL_VERSION, "0.4", [Define version of lcdproc client-server protocol])
 
 AC_DEFINE_UNQUOTED(API_VERSION, "0.5", [Define version of lcdproc API])
 

--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -377,7 +377,7 @@ of display available.
 
 .SS CLIENT COMMANDS
 There are many commands for the client to send to the LCDd server, here is
-the list of commands for version \fI0.3\fP of the protocol:
+the list of commands for versions \fI0.3\fP - \fI0.4\fP of the protocol:
 .TP
 .B hello
 This starts a client-server session with the LCDd server; the server will
@@ -389,7 +389,7 @@ The first 4 keyword value pairs are always wid, hgt, cellwid and cellhght,
 for backwards compatibility with older clients which are hardcoded to take
 the 8th and 10th words of the connect string as width and height. The
 connect string will look like this for example:
-"\fBconnect LCDproc 0.5dev protocol 0.3 lcd wid 17 hgt 4 cellwid 6 cellhgt 10\fP"
+"\fBconnect LCDproc 0.5dev protocol 0.4 lcd wid 17 hgt 4 cellwid 6 cellhgt 10\fP"
 .TP
 .B client_set -name \fIname\fP
 Set the client's name.
@@ -508,6 +508,10 @@ A horizontal bar graph.
 .B vbar
 A vertical bar graph.
 .TP
+.B pbar
+A-percentage bar, filled from left to right. This widget-type is only
+available on servers which report a \fIprotocol-version\fP of 0.4 or newer.
+.TP
 .B title
 A title displayed across the top of the display, within a banner.
 .TP
@@ -542,6 +546,13 @@ Displays a horizontal bar starting at position (\fIx\fP,\fIy\fP) that is \fIleng
 .TP
 .B vbar \fIx y length\fP
 Displays a vertical bar starting at position (\fIx\fP,\fIy\fP) that is \fIlength\fP pixels high.
+.TP
+.B pbar \fIx y width promille\fP [\fIbegin-label end-label\fP]
+Displays a percentage-bar starting at position (\fIx\fP,\fIy\fP) covering
+\fIwidth\fP character cells including the optional begin and end-labels,
+filled from left to right to the specified \fIpromille\fP value.
+Optionally a \fIbegin-label\fP and \fIend-label\fP can be specified which
+will be drawn in front of and after the percentage-bar.
 .TP
 .B icon \fIx y name\fP
 Displays the icon \fIname\fP at position (\fIx\fP,\fIy\fP).

--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -376,12 +376,20 @@ of display available.
 .PP
 
 .SS CLIENT COMMANDS
-There are many commands for the client to send to the LCDd server:
+There are many commands for the client to send to the LCDd server, here is
+the list of commands for version \fI0.3\fP of the protocol:
 .TP
 .B hello
-This starts a client-server session with the LCDd server; the
-server will return a data string detailing the type of display
-and its size.
+This starts a client-server session with the LCDd server; the server will
+return a white-space separated data string detailing the type of display
+and its size. The format of this string is:
+"\fBconnect LCDproc\fP <\fILCDd-version\fP> \fBprotocol\fP <\fIprotocol-version\fP> \fBlcd\fP [\fIkeyword value\fP] [\fIkeyword value\fP] ...".
+\fIprotocol-version\fP is always in the form of "\fImajor\fP.\fIminor\fP".
+The first 4 keyword value pairs are always wid, hgt, cellwid and cellhght,
+for backwards compatibility with older clients which are hardcoded to take
+the 8th and 10th words of the connect string as width and height. The
+connect string will look like this for example:
+"\fBconnect LCDproc 0.5dev protocol 0.3 lcd wid 17 hgt 4 cellwid 6 cellhgt 10\fP"
 .TP
 .B client_set -name \fIname\fP
 Set the client's name.

--- a/docs/lcdproc-dev/driver-api.docbook
+++ b/docs/lcdproc-dev/driver-api.docbook
@@ -104,6 +104,9 @@ typedef struct lcd_logical_driver {
 	void (*vbar)		(Driver *drvthis, int x, int y, int len, int promille, int options);
 	void (*hbar)		(Driver *drvthis, int x, int y, int len, int promille, int options);
 
+	// draw a progressbar covering lenght chars at pos (x,y) showing promille% progress
+	void (*pbar)		(Driver *drvthis, int x, int y, int len, int promille);
+
 	// display (big) number num at horizontal position x
 	void (*num)		(Driver *drvthis, int x, int num);
 
@@ -396,9 +399,30 @@ typedef struct MyDriver_private_data {
   </funcprototype>
 </funcsynopsis>
 <para>
-  Draw a horizontal bar at position (<replaceable>x</replaceable>,<replaceable>y</replaceable>)
+  Draw a solid horizontal bar at position (<replaceable>x</replaceable>,<replaceable>y</replaceable>)
   that has maximal length <replaceable>len</replaceable>, where a fraction of
-  (<replaceable>promille</replaceable> / 1000) is filled.
+  (<replaceable>promille</replaceable> / 1000) is filled. The non filled
+  part of the maximum length should not be drawn / touched by this function.
+</para>
+
+<funcsynopsis>
+  <funcprototype>
+	<funcdef>void <function>(*pbar)</function></funcdef>
+	<paramdef>Driver *<parameter>drvthis</parameter></paramdef>
+	<paramdef>int <parameter>x</parameter></paramdef>
+	<paramdef>int <parameter>y</parameter></paramdef>
+	<paramdef>int <parameter>len</parameter></paramdef>
+	<paramdef>int <parameter>promille</parameter></paramdef>
+  </funcprototype>
+</funcsynopsis>
+<para>
+  Draw a progress bar covering <replaceable>len</replaceable> characters at
+  position (<replaceable>x</replaceable>,<replaceable>y</replaceable>),
+  where a fraction of (<replaceable>promille</replaceable> / 1000) is filled.
+  Unlike a hbar, this function must draw a background for the the non-filled
+  part of the bar. For example this function may draw an outline in the form
+  of a (non-filled) rectangle covering the entire length and then fill part
+  of that rectangle to indicate the current progress.
 </para>
 
 <funcsynopsis>

--- a/docs/lcdproc-dev/language.docbook
+++ b/docs/lcdproc-dev/language.docbook
@@ -452,6 +452,14 @@
 		</varlistentry>
 		<varlistentry>
 		  <term>
+		    <literal>pbar</literal>
+		  </term>
+		  <listitem><para>
+		      A percentage / progress bar.
+		    </para></listitem>
+		</varlistentry>
+		<varlistentry>
+		  <term>
 		    <literal>icon</literal>
 		  </term>
 		  <listitem><para>
@@ -564,6 +572,27 @@
 		      vertical (<literal>vbar</literal>) starting at
 		      position (<replaceable>x</replaceable>,<replaceable>y</replaceable>)
 		      that is <replaceable>length</replaceable> pixels wide resp. high.
+		    </para></listitem>
+		</varlistentry>
+		<varlistentry>
+		  <term>
+		    <literal>pbar</literal>
+		  </term>
+		  <listitem>
+		    <cmdsynopsis>
+		      <arg choice="plain"><replaceable>x</replaceable></arg>
+		      <arg choice="plain"><replaceable>y</replaceable></arg>
+		      <arg choice="plain"><replaceable>width</replaceable></arg>
+		      <arg choice="plain"><replaceable>promille</replaceable></arg>
+		      <arg choice="opt"><replaceable>begin-label</replaceable></arg>
+		      <arg choice="opt"><replaceable>end-label</replaceable></arg>
+		    </cmdsynopsis>
+		    <para>
+		      Displays a horizontal (<literal>pbar</literal>) and its
+		      optional (<literal>begin-label</literal>) and (<literal>end-label</literal>)
+		      labels covering <replaceable>width</replaceable> characters starting at
+		      position (<replaceable>x</replaceable>,<replaceable>y</replaceable>)
+		      where a fraction of (<replaceable>promille</replaceable> / 1000) is filled.
 		    </para></listitem>
 		</varlistentry>
 		<varlistentry>

--- a/server/commands/widget_commands.c
+++ b/server/commands/widget_commands.c
@@ -296,6 +296,31 @@ widget_set_func(Client *c, int argc, char **argv)
 			sock_send_string(c->sock, "success\n");
 		}
 		break;
+	case WID_PBAR:			/* Pbar takes "x y width promille [begin-label end-label]" */
+		if (argc < i + 4 || argc > i + 6) {
+			sock_send_error(c->sock, "Wrong number of arguments\n");
+			break;
+		}
+		if ((!isdigit((unsigned int) argv[i][0])) ||
+		    (!isdigit((unsigned int) argv[i + 1][0]))) {
+			sock_send_error(c->sock, "Invalid coordinates\n");
+			break;
+		}
+		free(w->begin_label);
+		free(w->end_label);
+		w->begin_label = NULL;
+		w->end_label = NULL;
+		w->x = atoi(argv[i]);
+		w->y = atoi(argv[i + 1]);
+		w->width = atoi(argv[i + 2]);
+		w->promille = atoi(argv[i + 3]);
+		if (argc >= i + 5)
+			w->begin_label = strdup(argv[i + 4]);
+		if (argc >= i + 6)
+			w->end_label = strdup(argv[i + 5]);
+		debug(RPT_DEBUG, "Widget %s set to %i", wid, w->promille);
+		sock_send_string(c->sock, "success\n");
+		break;
 	case WID_ICON:			/* Icon takes "x y icon" */
 		if (argc != i + 3)
 			sock_send_error(c->sock, "Wrong number of arguments\n");

--- a/server/driver.h
+++ b/server/driver.h
@@ -46,6 +46,9 @@ driver_support_multiple(Driver *driver);
 bool
 driver_stay_in_foreground(Driver *driver);
 
+void
+driver_pbar(Driver *drv, int x, int y, int width, int promille, char *begin_label, char *end_label);
+
 
 /* Alternative functions for all extended functions */
 

--- a/server/drivers.c
+++ b/server/drivers.c
@@ -310,6 +310,30 @@ drivers_hbar(int x, int y, int len, int promille, int pattern)
 
 
 /**
+ * Draw a percentage-bar to all drivers.
+ * \param x            Horizontal character position (column) of the starting point.
+ * \param y            Vertical character position (row) of the starting point.
+ * \param width        Width of the widget in characters, including the
+ *                     optional begin and end-labels.
+ * \param promille     Current length level of the bar in promille.
+ * \param begin_label  Optional (may be NULL) text to render in front of /
+ *                     at the beginning of the percentage-bar.
+ * \param end_label    Optional text to render at the end of the pbar.
+ *
+ * Note the driver may choose to not render the labels if there is not enough
+ * space.
+ */
+void
+drivers_pbar(int x, int y, int width, int promille, char *begin_label, char *end_label)
+{
+	Driver *drv;
+
+	ForAllDrivers(drv)
+		driver_pbar(drv, x, y, width, promille, begin_label, end_label);
+}
+
+
+/**
  * Write a big number to all output drivers.
  * For drivers that define a num() function, call it;
  * otherwise call the general driver_alt_num() function from the server core.

--- a/server/drivers.h
+++ b/server/drivers.h
@@ -50,6 +50,9 @@ void
 drivers_hbar(int x, int y, int len, int promille, int pattern);
 
 void
+drivers_pbar(int x, int y, int width, int promille, char *begin_label, char *end_label);
+
+void
 drivers_num(int x, int num);
 
 void

--- a/server/drivers/lcd.h
+++ b/server/drivers/lcd.h
@@ -156,6 +156,7 @@ typedef struct lcd_logical_driver {
 	/* extended output functions (optional; core provides alternatives) */
 	void (*vbar)		(struct lcd_logical_driver *drvthis, int x, int y, int len, int promille, int pattern);
 	void (*hbar)		(struct lcd_logical_driver *drvthis, int x, int y, int len, int promille, int pattern);
+	void (*pbar)		(struct lcd_logical_driver *drvthis, int x, int y, int width, int promille);
 	void (*num)		(struct lcd_logical_driver *drvthis, int x, int num);
 	void (*heartbeat)	(struct lcd_logical_driver *drvthis, int state);
 	int (*icon)		(struct lcd_logical_driver *drvthis, int x, int y, int icon);

--- a/server/drivers/mx5000.c
+++ b/server/drivers/mx5000.c
@@ -303,17 +303,16 @@ mx5000_backlight (Driver *drvthis, int on)
 }
 
 /*
- * Draws a horizontal bar to the right.
- */
-MODULE_EXPORT void
-mx5000_hbar (Driver *drvthis, int x, int y, int len, int promille, int options)
-{
-/* x and y are the start position of the bar.
+ * Draws a progressbar.
+ * x and y are the start position of the bar.
  * The bar by default grows in the 'right' direction
  * (other direction not yet implemented).
  * len is the number of characters that the bar is long at 100%
  * promille is the number of promilles (0..1000) that the bar should be filled.
  */
+MODULE_EXPORT void
+mx5000_pbar (Driver *drvthis, int x, int y, int len, int promille)
+{
     PrivateData *p = drvthis->private_data;
     // The position should be given in pixels
     int px, py;

--- a/server/render.c
+++ b/server/render.c
@@ -66,6 +66,7 @@ static void render_frame(LinkedList *list, int left, int top, int right, int bot
 static void render_string(Widget *w, int left, int top, int right, int bottom, int fy);
 static void render_hbar(Widget *w, int left, int top, int right, int bottom, int fy);
 static void render_vbar(Widget *w, int left, int top, int right, int bottom);
+static void render_pbar(Widget *w, int left, int top, int right, int bottom);
 static void render_title(Widget *w, int left, int top, int right, int bottom, long timer);
 static void render_scroller(Widget *w, int left, int top, int right, int bottom, long timer);
 static void render_num(Widget *w, int left, int top, int right, int bottom);
@@ -260,6 +261,9 @@ render_frame(LinkedList *list,
 		case WID_VBAR:	  /* FIXME:  Vbars don't work in frames! */
 			render_vbar(w, left, top, right, bottom);
 			break;
+		case WID_PBAR:
+			render_pbar(w, left, top - fy, right, bottom);
+			break;
 		case WID_ICON:	  /* FIXME:  Icons don't work in frames! */
 			drivers_icon(w->x, w->y, w->length);
 			break;
@@ -376,6 +380,18 @@ render_vbar(Widget *w, int left, int top, int right, int bottom)
 	}
 }
 
+static void
+render_pbar(Widget *w, int left, int top, int right, int bottom)
+{
+	debug(RPT_DEBUG, "%s(w=%p, left=%d, top=%d, right=%d, bottom=%d)",
+			  __FUNCTION__, w, left, top, right, bottom);
+
+	if (!((w->x > 0) && (w->y > 0) && (w->width > 0)))
+		return;
+
+        drivers_pbar(w->x + left, w->y + top, w->width, w->promille,
+       		     w->begin_label, w->end_label);
+}
 
 static void
 render_title(Widget *w, int left, int top, int right, int bottom, long timer)

--- a/server/widget.c
+++ b/server/widget.c
@@ -33,6 +33,7 @@ char *typenames[] = {
 	"string",	/* WID_STRING */
 	"hbar",		/* WID_HBAR */
 	"vbar",		/* WID_VBAR */
+	"pbar",		/* WID_PBAR */
 	"icon",		/* WID_ICON */
 	"title",	/* WID_TITLE */
 	"scroller",	/* WID_SCROLLER */
@@ -85,7 +86,7 @@ widget_create(char *id, WidgetType type, Screen *screen)
 	debug(RPT_DEBUG, "%s(id=\"%s\", type=%d, screen=[%s])", __FUNCTION__, id, type, screen->id);
 
 	/* Create it */
-	w = malloc(sizeof(Widget));
+	w = calloc(1, sizeof(Widget));
 	if (w == NULL) {
 		report(RPT_DEBUG, "%s: Error allocating", __FUNCTION__);
 		return NULL;

--- a/server/widget.h
+++ b/server/widget.h
@@ -23,6 +23,7 @@ typedef enum WidgetType {
 	WID_STRING,
 	WID_HBAR,
 	WID_VBAR,
+	WID_PBAR,
 	WID_ICON,
 	WID_TITLE,
 	WID_SCROLLER,
@@ -41,7 +42,10 @@ typedef struct Widget {
 	int left, top, right, bottom;	/**< bounding rectangle */
 	int length;			/**< size or direction */
 	int speed;			/**< For scroller... */
+	int promille;                   /**< For percentage / pbars */
 	char *text;			/**< text or binary data */
+	char *begin_label;		/**< label in front of pbars; or NULL */
+	char *end_label;		/**< label at end of pbars; or NULL */
 	struct Screen *frame_screen;	/**< frame widget get an associated screen */
 	//LinkedList *kids;		/* Frames can contain more widgets...*/
 } Widget;


### PR DESCRIPTION
This pull-req extends the "widget_set screen widget_name parm1 parm2 parm3" syntax for hbars and vbars with an optional new  "widget_set screen widget_name parm1 parm2 parm3 parm4" syntax.

The reason for this is to address the current widget_set syntax for bar widgets and the driver vbar / hbar being mismatched wrt each other and to avoid the hacks / problems this mismatch causes.

Specifically the old 3 parameter widget_set syntax for bars takes the usual x and y parameters as parm1 and parm2 and then the 3th argument is the length of the filled-part of the bar to draw in pixels. The drivers however expect x, y, length of the entire bar (not just the filled part) in characters and a filled promillage.

To workaround this mismatch, the render code in the server currently has this hack for hbars:
```
		int full_len = display_props->width - w->x - left + 1;
		int promille = 1000;

		if ((w->length / display_props->cellwidth) < right - left - w->x + 1)
			promille = (long) 1000 * w->length / (display_props->cellwidth * full_len);

		drivers_hbar(w->x + left, w->y + top, full_len, promille, BAR_PATTERN_FILLED);
```

This tells the driver to render a hbar with a length which reaches all the way to the right edge of the display. If you look at the 4 line standard cpu screen, this means that the length overwrites the "100%" text after the bar on the 4th line. Likewise for the 4 line standard mem screen, which has 2 small bars on the bottom, the mem bar overwrites the F E [swap-hbar ] F part of the display and the swap-bar length overwrites the F at the end of the 4th line. This all works without the 100% / F E [] F text which is only rendered once disappearing because most drivers only render the full part of the hbar, simply never drawing the unfilled-part of the bar, relying on that part of the LCD being empty. Except it is not empty, but not overwriting what is there is desirable because of the widget_set vs driver API mismatch.

So this mostly works as is, but IMHO the current state is a big hack. And this hack is causing problems for some drivers, specifically for the mx5000 driver. libmx5000 has its own hbar implementation and the lcdproc mx5000 driver is just a wrapper around this. But the mx5000 hbars consist of special begin (full or empty) middle (full or empty) and end characters, see:

https://fedorapeople.org/~jwrdegoede/cpu.png
https://fedorapeople.org/~jwrdegoede/mem.png

Note these pictures are how things look **with** the patches from this pull-req. The mx5000 code actually renders empty middle and end chars for the non-filled part of the hbar, breaking the assumption of the code working around the API mismatch that for the non-filled part nothing is rendered. This means that the end of the hbar overwrites the 100% in the CPU screen and the F E [] F text in the mem screen also gets overwritten which looks really ugly.

The first commit in this series fixes the API mismatch by introducing a new 4 parameter widget_set syntax for bars which matches the driver API. This new  widget_set syntax for bars is IMHO also easier to use by various screen code since it avoids the need to convert something like a CPU load to a filled-part of the bar in pixels unit.

The other commits in this pull-req convert the hbar usage in the standard lcdproc client cpu and mem screens to use the new syntax, fixing the issues with those screens on the mx5000.

Note that support for the old 3 parameter syntax is kept unchanged, to avoid clients relying on that breaking.

Besides fixing the mx5000 hbars this will also allow other (graphical) displays to potentially draw nicer bars then currently is done.