### PR TITLE
Client language: Update key handling

### DIFF
--- a/docs/LCDd.8.in
+++ b/docs/LCDd.8.in
@@ -377,7 +377,9 @@ of display available.
 
 .SS CLIENT COMMANDS
 There are many commands for the client to send to the LCDd server, here is
-the list of commands for versions \fI0.3\fP - \fI0.4\fP of the protocol:
+a list of the most important commands for versions \fI0.3\fP - \fI0.4\fP
+of the protocol. For a full command reference see the
+\fILCDProc Developers Guide\fP:
 .TP
 .B hello
 This starts a client-server session with the LCDd server; the server will

--- a/docs/lcdproc-dev/language.docbook
+++ b/docs/lcdproc-dev/language.docbook
@@ -403,6 +403,49 @@
 
 	<varlistentry>
 	  <term>
+	    <command>key_add
+	      <option><replaceable>screen_id</replaceable></option>
+	      <option><replaceable>key</replaceable></option>...
+	    </command>
+	    since protocol version 0.4
+	  </term>
+	  <listitem>
+	    <para>
+	      Reserves key(s) for interaction of the user with the screen.
+	      Reservations with this command always take precedence over
+	      reservations with <command>client_add_key</command>, but are
+	      only in effect while the screen is visible on the display.
+	      The server message on key events is appended with
+	      <replaceable>screen_id</replaceable> to distinguish it from
+	      client level key events.
+	    </para>
+
+	    <para>
+	      Only one success message is generated for all keys together.
+	    </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
+	  <term>
+	    <command>key_del
+	      <option><replaceable>screen_id</replaceable></option>
+	      <option><replaceable>key</replaceable></option>...
+	    </command>
+	    since protocol version 0.4
+	  </term>
+	  <listitem>
+	    <para>
+	      Lift reservation of key(s) by <command>key_add</command>.
+	      Arguments are processed sequentially and for each one either
+	      a success message is generated or an error message, if the
+	      key was not found in the list of reserved keys.
+	    </para>
+	  </listitem>
+	</varlistentry>
+
+	<varlistentry>
+	  <term>
 	    <command>widget_add
 	      <option><replaceable>screen_id</replaceable></option>
 	      <option><replaceable>new_widget_id</replaceable></option>
@@ -760,14 +803,22 @@
 	      given key(s). If you reserve the key(s) in shared mode, other
 	      clients can still reserve these keys too. If you reserve the key(s)
 	      in exclusive mode no other client can reserve them again.
+	      Shared mode is the default.
+	    </para>
+	    <para>
 	      Key(s) reserved in shared mode will only be returned when a screen
 	      of the current client is active. These keys can be used for
-	      interaction with a visible screen (default).
+	      interaction with a visible screen.
 	      Key(s) reserved in exclusive mode will be returned regardless of
 	      which screen is active. They can be used to trigger a special
 	      feature or to make a screen come to foreground.
+	    </para>
+	    <para>
 	      Note that you cannot reserve a key in exclusive mode when an
-	      other client has reserved it in shared mode.
+	      other client has reserved it in shared mode. However a key
+	      can be reserved in exclusive mode and on a per screen basis
+	      with <command>key_add</command> just fine. (In this case
+	      the per screen reservation wins.)
 	    </para>
 	  </listitem>
 	</varlistentry>

--- a/docs/lcdproc-dev/language.docbook
+++ b/docs/lcdproc-dev/language.docbook
@@ -820,6 +820,12 @@
 	      with <command>key_add</command> just fine. (In this case
 	      the per screen reservation wins.)
 	    </para>
+	    <para>
+	      Starting with protocol version 0.4 for each
+	      <replaceable>key</replaceable> argument the server answers
+	      with either a success message or an error message if there
+	      is a reservation conflict.
+	    </para>
 	  </listitem>
 	</varlistentry>
 
@@ -831,7 +837,8 @@
 	  </term>
 	  <listitem>
 	    <para>
-	      Ends the reservation of the given key(s).
+	      Ends the reservation of the given key(s). Always returns
+	      exactly one success message.
 	    </para>
 	  </listitem>
 	</varlistentry>

--- a/server/commands/client_commands.c
+++ b/server/commands/client_commands.c
@@ -194,12 +194,11 @@ client_add_key_func(Client *c, int argc, char **argv)
 		}
 		argnr++;
 	}
-	for ( ; argnr < argc; argnr++) {
-		if (input_reserve_key(argv[argnr], exclusively, c) < 0) {
+	for ( ; argnr < argc; argnr++)
+		if (input_reserve_key(argv[argnr], exclusively, c) < 0)
 			sock_printf_error(c->sock, "Could not reserve key \"%s\"\n", argv[argnr]);
-		}
-	}
-	sock_send_string(c->sock, "success\n");
+		else
+			sock_send_string(c->sock, "success\n");
 
 	return 0;
 }

--- a/server/commands/command_list.c
+++ b/server/commands/command_list.c
@@ -33,6 +33,8 @@ static client_function commands[] = {
 	{ "screen_add",     screen_add_func     },
 	{ "screen_del",     screen_del_func     },
 	{ "screen_set",     screen_set_func     },
+	{ "key_add",        key_add_func	},
+	{ "key_del",        key_del_func	},
 	{ "widget_add",     widget_add_func     },
 	{ "widget_del",     widget_del_func     },
 	{ "widget_set",     widget_set_func     },

--- a/server/commands/screen_commands.h
+++ b/server/commands/screen_commands.h
@@ -15,6 +15,8 @@
 int screen_add_func(Client *c, int argc, char **argv);
 int screen_del_func(Client *c, int argc, char **argv);
 int screen_set_func(Client *c, int argc, char **argv);
+int key_add_func(Client *c, int argc, char **argv);
+int key_del_func(Client *c, int argc, char **argv);
 
 #endif
 

--- a/server/input.c
+++ b/server/input.c
@@ -78,7 +78,6 @@ void input_shutdown()
 }
 
 
-
 void handle_input(void)
 {
 	const char *key;
@@ -96,6 +95,13 @@ void handle_input(void)
 
 	/* Handle all keypresses */
 	while ((key = drivers_get_key()) != NULL) {
+
+		/* keys from key_add have highest priority */
+		if (current_screen && screen_find_key(current_screen, key)) {
+			sock_printf(current_client->sock, "key %s %s\n",
+				    key, current_screen->id);
+			continue;
+		}
 
 		/* Find what client wants the key */
 		kr = input_find_key(key, current_client);

--- a/server/screen.h
+++ b/server/screen.h
@@ -51,6 +51,7 @@ typedef struct Screen {
 	short int cursor_x;
 	short int cursor_y;
 	char *keys;
+	int keys_size;
 	LinkedList *widgetlist;
 	struct Client *client;
 } Screen;
@@ -72,7 +73,7 @@ extern int  default_priority ;
 Screen *screen_create(char *id, Client *client);
 
 /* Destroys a screen */
-int screen_destroy(Screen *s);
+void screen_destroy(Screen *s);
 
 /* Add a widget to a screen */
 int screen_add_widget(Screen *s, Widget *w);
@@ -98,6 +99,9 @@ static inline Widget *screen_getnext_widget(Screen *s)
 
 /* Find a widget in a screen */
 Widget *screen_find_widget(Screen *s, char *id);
+
+/* Test if key is used by screen */
+char *screen_find_key(Screen *s, const char *key);
 
 /* Convert priority names to priority and vv */
 Priority screen_pri_name_to_pri(char *pri_name);


### PR DESCRIPTION
Hi all,

this is yet an other change where I'd like to have some input from the
community before pushing them to master. Of course code reviews
are always welcome, but even more important is proof reading the docs
(english is not my native language) and comments wether these
changes are a good idea at all.

The new commands allow to reserve keys per screen instead of per client.
This hopefully has clearer semantics then client_add_key in shared mode.
Also for clients with multiple screens this allows to have interaction
with just some of the screens while others still benefit from internal
key handling in the server.

TIA,
Harald