### PR TITLE
Menu fixes

### DIFF
--- a/server/input.c
+++ b/server/input.c
@@ -99,7 +99,7 @@ void handle_input(void)
 
 		/* Find what client wants the key */
 		kr = input_find_key(key, current_client);
-		if (kr) {
+		if (kr && kr->client) {
 			/* A hit ! */
 			debug(RPT_DEBUG, "%s: reserved key: \"%.40s\"", __FUNCTION__, key);
 			sock_printf(kr->client->sock, "key %s\n", key);

--- a/server/menu.c
+++ b/server/menu.c
@@ -710,7 +710,10 @@ MenuResult menu_process_input(Menu *menu, MenuToken token, const char *key, unsi
 		else if (menu->data.menu.selector_pos == 0) {
 			// wrap around to last menu entry
 			menu->data.menu.selector_pos = menu_visible_item_count(menu) - 1;
-			menu->data.menu.scroll = menu->data.menu.selector_pos + 2 - display_props->height;
+			if (menu_visible_item_count(menu) >= display_props->height)
+				menu->data.menu.scroll = menu->data.menu.selector_pos + 2 - display_props->height;
+			else
+				menu->data.menu.scroll = 0;
 		}
 		return MENURESULT_NONE;
 	  case MENUTOKEN_DOWN:


### PR DESCRIPTION
This pull-req contains 2 small menu fixes.

The first commit fixes a crash when pressing the Menu button which was introduced by commit 2017fdaaf0fa ("server/input: Cleanup").

The second commit fixes a scrolling problem when the number of menu entries is smaller then the display's height.