### PR TITLE
Various improvements for the Linux input driver

### DIFF
--- a/LCDd.conf
+++ b/LCDd.conf
@@ -871,7 +871,9 @@ Size=16x2
 ## Linux event device input driver ##
 [linux_input]
 
-# Select the input device to use [default: /dev/input/event0]
+# Select the input device to use [default: /dev/input/event0]. This may be
+# either an absolute path to the input node, starting with '/', or
+# an input device name, e.g. "Logitech Gaming Keyboard Gaming Keys".
 # Device=/dev/input/event0
 
 # specify a non-default key map

--- a/docs/lcdproc-user/drivers/linux_input.docbook
+++ b/docs/lcdproc-user/drivers/linux_input.docbook
@@ -39,8 +39,10 @@ This section covers the linux event device input driver for LCDd.
 
     <para>
     <replaceable>KEYCODE</replaceable> is an integer like the ones defined in
-    <filename>/usr/include/linux/input.h</filename>. You can also find the
-    key code in the log output of <application>LCDd</application> when the
+    <filename>/usr/include/linux/input.h</filename>. This may be specified
+    as either a decimal number, or as a hexadecimal number prefixed with 0x.
+    You can also find the key code in the log output of
+    <application>LCDd</application> when the
     <link linkend="server-section"><parameter>ReportLevel</parameter></link>
     is at least 4.
     </para>

--- a/docs/lcdproc-user/drivers/linux_input.docbook
+++ b/docs/lcdproc-user/drivers/linux_input.docbook
@@ -19,7 +19,9 @@ This section covers the linux event device input driver for LCDd.
     <parameter><replaceable>DEVICE</replaceable></parameter>
   </term>
   <listitem><para>
-    Select the input device to use [default: <filename>/dev/input/event0</filename>]
+    Select the input device to use [default: <filename>/dev/input/event0</filename>].
+    This may be either an absolute path to the input node, starting with '/',
+    or an input device name, e.g. "Logitech Gaming Keyboard Gaming Keys".
   </para></listitem>
 </varlistentry>
 

--- a/server/drivers/linux_input.c
+++ b/server/drivers/linux_input.c
@@ -42,11 +42,11 @@ struct keycode {
 static struct keycode *
 keycode_create(const char *configvalue)
 {
-	int code;
+	long code;
 	char *button;
 	struct keycode *ret;
 
-	code = atoi(configvalue);
+	code = strtol(configvalue, NULL, 0);
 	if (code < 0 || code > UINT16_MAX)
 		return NULL;
 

--- a/server/drivers/linux_input.c
+++ b/server/drivers/linux_input.c
@@ -3,12 +3,14 @@
  * subsystem of the linux kernel..
  */
 
+#include <dirent.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -77,6 +79,60 @@ MODULE_EXPORT int stay_in_foreground = 0;
 MODULE_EXPORT int supports_multiple = 1;
 MODULE_EXPORT char *symbol_prefix = "linuxInput_";
 
+static int linuxInput_open_with_name(const char *device, const char *name)
+{
+	char buf[256];
+	int err, fd;
+
+	fd = open(device, O_RDONLY | O_NONBLOCK);
+	if (fd == -1)
+		return -1;
+
+	err = ioctl(fd, EVIOCGNAME(256), buf);
+	if (err == -1) {
+		close(fd);
+		return -1;
+	}
+	/* The kernel does not add a 0 terminator if the name is too long */
+	buf[255] = 0;
+
+	if (strcmp(buf, name)) {
+		/* Not the device we are looking for */
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+static int linuxInput_search_by_name(const char *name)
+{
+	char devname[PATH_MAX];
+	struct dirent *dirent;
+	int fd = -1;
+	DIR *dir;
+
+	dir = opendir("/dev/input");
+	if (dir == NULL)
+		return -1;
+
+	while ((dirent = readdir(dir)) != NULL) {
+		if (dirent->d_type != DT_CHR ||
+		    strncmp(dirent->d_name, "event", 5))
+			continue;
+
+		strcpy(devname, "/dev/input/");
+		strcat(devname, dirent->d_name);
+
+		fd = linuxInput_open_with_name(devname, name);
+		if (fd != -1)
+			break;
+	}
+
+	closedir(dir);
+
+	return fd;
+}
 
 /**
  * Initialize the driver.
@@ -114,10 +170,19 @@ linuxInput_init (Driver *drvthis)
 	report(RPT_INFO, "%s: using Device %s", drvthis->name, s);
 
 
-	if ((p->fd = open(s, O_RDONLY | O_NONBLOCK)) < 0) {
-		report(RPT_ERR, "%s: open(%s) failed (%s)",
-				drvthis->name, s, strerror(errno));
-		return -1;
+	/* Open the device, eiher by path or by name */
+	if (s[0] == '/') {
+		if ((p->fd = open(s, O_RDONLY | O_NONBLOCK)) == -1) {
+			report(RPT_ERR, "%s: open(%s) failed (%s)",
+					drvthis->name, s, strerror(errno));
+			return -1;
+		}
+	} else {
+		if ((p->fd = linuxInput_search_by_name(s)) == -1) {
+			report(RPT_ERR, "%s: could not find '%s' input-device",
+					drvthis->name, s);
+			return -1;
+		}
 	}
 
 	for (i = 0; (s = drvthis->config_get_string(drvthis->name, "key", i, NULL)) != NULL; i++) {

--- a/server/drivers/linux_input.c
+++ b/server/drivers/linux_input.c
@@ -294,34 +294,35 @@ linuxInput_get_key (Driver *drvthis)
 	if (event.type != EV_KEY || event.value == 0)
 		return NULL;
 
-	switch (event.code) {
-	case KEY_ESC:
-		return "Escape";
-
-	case KEY_UP:
-		return "Up";
-
-	case KEY_LEFT:
-		return "Left";
-
-	case KEY_RIGHT:
-		return "Right";
-
-	case KEY_DOWN:
-		return "Down";
-
-	case KEY_ENTER:
-	case KEY_KPENTER:
-		return "Enter";
-
-	default:
-		LL_Rewind(p->buttonmap);
+	if (LL_GetFirst(p->buttonmap)) {
+		/* Use user config for button mapping */
 		k = LL_Find(p->buttonmap, compare_with_keycode, &event.code);
 		if (k)
 			return k->button;
-		else
-			report(RPT_INFO, "linux_input: Unknown key code: %d", event.code);
+	} else {
+		/* No user config, fallback to defaults. */
+		switch (event.code) {
+		case KEY_ESC:
+			return "Escape";
 
-		return NULL;
+		case KEY_UP:
+			return "Up";
+
+		case KEY_LEFT:
+			return "Left";
+
+		case KEY_RIGHT:
+			return "Right";
+
+		case KEY_DOWN:
+			return "Down";
+
+		case KEY_ENTER:
+		case KEY_KPENTER:
+			return "Enter";
+		}
 	}
+
+	report(RPT_INFO, "linux_input: Unknown key code: %d", event.code);
+	return NULL;
 }

--- a/server/drivers/mx5000.h
+++ b/server/drivers/mx5000.h
@@ -35,7 +35,6 @@ typedef struct mx5000_private_data {
     char device[200];
     int wait;
     int fd;
-    int input_fd;
     struct MX5000ScreenContent *sc;
     char info[255];
     char changed;


### PR DESCRIPTION
Various improvements for the Linux input driver:

- Allow opening the input device by device-name
- Re-acquire the device on connection loss
- Drop no longer needed custom mx5000 input handling
