### PR TITLE
Revert "server: Don't use alloca() - use C99 instead"

### DIFF
--- a/server/drivers.c
+++ b/server/drivers.c
@@ -10,6 +10,7 @@
  * Copyright(c) 2001, Joris Robijn
  */
 
+#include <alloca.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -48,6 +49,8 @@ drivers_load_driver(const char *name)
 {
 	Driver *driver;
 	const char *s;
+	char *driverpath;
+	char *filename;
 
 	debug(RPT_DEBUG, "%s(name=\"%.40s\")", __FUNCTION__, name);
 
@@ -63,16 +66,16 @@ drivers_load_driver(const char *name)
 
 	/* Retrieve data from config file */
 	s = config_get_string("server", "DriverPath", 0, "");
-	char driverpath[strlen(s) + 1];
+	driverpath = alloca(strlen(s) + 1);
 	strcpy(driverpath, s);
 
 	s = config_get_string(name, "File", 0, NULL);
-	char filename[strlen(driverpath) + strlen(s) + strlen(name) +
-			sizeof(MODULE_EXTENSION)];
 	if (s) {
+		filename = alloca(strlen(driverpath) + strlen(s) + 1);
 		strcpy(filename, driverpath);
 		strcat(filename, s);
 	} else {
+		filename = alloca(strlen(driverpath) + strlen(name) + strlen(MODULE_EXTENSION) + 1);
 		strcpy(filename, driverpath);
 		strcat(filename, name);
 		strcat(filename, MODULE_EXTENSION);

--- a/server/parse.c
+++ b/server/parse.c
@@ -15,6 +15,7 @@
  *               2008, Peter Marschall
  */
 
+#include <alloca.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -55,7 +56,7 @@ static void parse_message(const char *str, Client *c)
 	int error = 0;
 	char quote = '\0';	/* The quote used to open a quote string */
 	int pos = 0;
-	char arg_space[strlen(str)+1];
+	char *arg_space;
 	int argc = 0;
 	char *argv[MAX_ARGUMENTS];
 	int argpos = 0;
@@ -66,6 +67,8 @@ static void parse_message(const char *str, Client *c)
 	/* We will create a list of strings that is shorter or equally long as
 	 * the original string str.
 	 */
+	arg_space = alloca(strlen(str)+1);
+
 	argv[0] = arg_space;
 
 	while ((state != ST_FINAL) && !error) {

--- a/server/widget.c
+++ b/server/widget.c
@@ -15,6 +15,7 @@
  *		 2008, Peter Marschall
  */
 
+#include <alloca.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -100,7 +101,7 @@ widget_create(char *id, WidgetType type, Screen *screen)
 
 	if (type == WID_FRAME) {
 		/* create a screen for the frame widget */
-		char frame_name[sizeof("frame_") + strlen(id)];
+		char *frame_name = alloca(sizeof("frame_") + strlen(id));
 
 		strcpy(frame_name, "frame_");
 		strcat(frame_name, id);


### PR DESCRIPTION
Commit d8810f2f7d18 ("server: Don't use alloca() - use C99 instead")
replaces:

	if (s) {
		filename = alloca(strlen(driverpath) + strlen(s) + 1);
		...
	} else {
		filename = alloca(strlen(driverpath) + strlen(name) + strlen(MODULE_EXTENSION) + 1);
		...
	}

With:

	char filename[strlen(driverpath) + strlen(s) + strlen(name) +
			sizeof(MODULE_EXTENSION)];
	if (s) {
		...
	} else {
		...
	}

Causing a NULL pointer dereference of s if s is not set, causing LCDd to
crash.

This reverts commit d8810f2f7d184c87a012fb30b004abac838ec601, fixing this
crash.