### PR TITLE
Add support for a second CE pin to the ftdi connection mode.

### DIFF
--- a/docs/lcdproc-user/drivers/hd44780.docbook
+++ b/docs/lcdproc-user/drivers/hd44780.docbook
@@ -1978,7 +1978,9 @@ will not work. Use the following instead.
 
 <para>
 Alternatively you can use a single channel FTDI FT245BM USB &lt;-&gt; parallel
-FIFO chip and use the display in its 4 bit mode.
+FIFO chip and use the display in its 4 bit mode. If the LCD display you are
+using has two chip selects, then also configure CE2, and set RW to 0x00. Don't
+forget to wire RW to ground.
 </para>
 
 <table id="hd44780-ftdi.4bit-mapping">
@@ -2053,6 +2055,13 @@ FIFO chip and use the display in its 4 bit mode.
       <entry>5</entry>
     </row>
     <row>
+      <entry>D6</entry>
+      <entry>19</entry>
+      <entry></entry>
+      <entry>EN2</entry>
+      <entry>(alternative)</entry>
+    </row>
+    <row>
       <entry>D7</entry>
       <entry>18</entry>
       <entry></entry>
@@ -2079,6 +2088,7 @@ ftdi_line_EN=0x10
 ftdi_line_RS=0x20
 ftdi_line_RW=0x40
 ftdi_line_backlight=0x80
+#ftdi_line_EN2=0x40
 ]]>
 </screen>
 </example>

--- a/server/drivers/hd44780-ftdi.c
+++ b/server/drivers/hd44780-ftdi.c
@@ -202,68 +202,70 @@ ftdi_HD44780_senddata(PrivateData *p, unsigned char displayID, unsigned char fla
 {
     unsigned char enableLines = 0;
     /* Which EN to control */
-    if (displayID == 1 || displayID == 0)
-            enableLines |= p->ftdi_line_EN;
-    if (displayID == 2 || (p->numDisplays > 1 && displayID == 0))
-            enableLines |= p->ftdi_line_EN2;
+    if (displayID == 1 || displayID == 0) {
+        enableLines |= p->ftdi_line_EN;
+    }
+    if (displayID == 2 || (p->numDisplays > 1 && displayID == 0)) {
+        enableLines |= p->ftdi_line_EN2;
+    }
 
     if (p->ftdi_mode == 8) {
-	    /* Output data on first channel */
-	    int f = ftdi_write_data(&p->ftdic, &ch, 1);
-	    if (f < 0) {
-	        p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
-				           f, ftdi_get_error_string(&p->ftdic));
-	        exit(-1);
-	    }
+	/* Output data on first channel */
+	int f = ftdi_write_data(&p->ftdic, &ch, 1);
+	if (f < 0) {
+	    p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
+				       f, ftdi_get_error_string(&p->ftdic));
+	    exit(-1);
+	}
 
-	    /* Setup RS and R/W and EN on second channel */
-	    ch = enableLines | p->backlight_bit;
-	    if (flags == RS_DATA) {
-	        ch |= p->ftdi_line_RS;
-	    }
-	    f = ftdi_write_data(&p->ftdic2, &ch, 1);
-	    if (f < 0) {
-	        p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
-				          f, ftdi_get_error_string(&p->ftdic2));
-	        exit(-1);
-	    }
+	/* Setup RS and R/W and EN on second channel */
+	ch = enableLines | p->backlight_bit;
+	if (flags == RS_DATA) {
+	    ch |= p->ftdi_line_RS;
+	}
+	f = ftdi_write_data(&p->ftdic2, &ch, 1);
+	if (f < 0) {
+	    p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
+				      f, ftdi_get_error_string(&p->ftdic2));
+	    exit(-1);
+	}
 
-	    /* Disable EN */
-	    ch = 0x00 | p->backlight_bit;
-	    if (flags == RS_DATA) {
-	        ch |= p->ftdi_line_RS;
-	    }
-	    f = ftdi_write_data(&p->ftdic2, &ch, 1);
-	    if (f < 0) {
-	        p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
-				          f, ftdi_get_error_string(&p->ftdic2));
-	        exit(-1);
-	    }
+	/* Disable EN */
+	ch = 0x00 | p->backlight_bit;
+	if (flags == RS_DATA) {
+	    ch |= p->ftdi_line_RS;
+	}
+	f = ftdi_write_data(&p->ftdic2, &ch, 1);
+	if (f < 0) {
+	    p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
+				      f, ftdi_get_error_string(&p->ftdic2));
+	    exit(-1);
+	}
     }
     else if (p->ftdi_mode == 4) {
-	    unsigned char buf[4];
-	    unsigned char portControl = 0;
+	unsigned char buf[4];
+	unsigned char portControl = 0;
 
-	    portControl = 0x00 | p->backlight_bit;
-	    if (flags == RS_DATA) {
-	        portControl |= p->ftdi_line_RS;
-	    }
+	portControl = 0x00 | p->backlight_bit;
+	if (flags == RS_DATA) {
+	    portControl |= p->ftdi_line_RS;
+	}
 
-	    buf[0] = ((ch >> 4) & 0x0F) | portControl | enableLines;
-	    buf[1] = ((ch >> 4) & 0x0F) | portControl;
-	    buf[2] = (ch & 0x0F) | portControl | enableLines;
-	    buf[3] = (ch & 0x0F) | portControl;
-	    int f = ftdi_write_data(&p->ftdic, buf, 4);
+	buf[0] = ((ch >> 4) & 0x0F) | portControl | enableLines;
+	buf[1] = ((ch >> 4) & 0x0F) | portControl;
+	buf[2] = (ch & 0x0F) | portControl | enableLines;
+	buf[3] = (ch & 0x0F) | portControl;
+	int f = ftdi_write_data(&p->ftdic, buf, 4);
 
-	    if (f < 0) {
-	        p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
-				           f, ftdi_get_error_string(&p->ftdic));
-	        exit(-1);
-	    }
+	if (f < 0) {
+	    p->hd44780_functions->drv_report(RPT_ERR, "failed to write: %d (%s). Exiting",
+				       f, ftdi_get_error_string(&p->ftdic));
+	    exit(-1);
+	}
 
-	    if (flags == RS_INSTR) {
-	        usleep(4100);
-	    }
+	if (flags == RS_INSTR) {
+	    usleep(4100);
+	}
     }
 }
 

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -208,6 +208,7 @@ typedef struct hd44780_private_data {
 	int ftdi_line_RS;
 	int ftdi_line_RW;
 	int ftdi_line_EN;
+	int ftdi_line_EN2;
 	int ftdi_line_backlight;
 #endif
 


### PR DESCRIPTION
Added support for CE2 to the ftdi connection mode of the HD44780 driver.

- Defined as "ftdi_line_EN2" in config file
- Defined as "ftdi_line_EN2" in private data structure
- Also updated the doco.