### PR TITLE
server/drivers/hd44780: Fill spi_ioc_transfer structure completely

### DIFF
--- a/server/drivers/hd44780-pifacecad.c
+++ b/server/drivers/hd44780-pifacecad.c
@@ -126,6 +126,7 @@ mcp23s17_write_reg(PrivateData *p, unsigned char reg, unsigned char data)
 	unsigned char rx_buf[3];
 
 	struct spi_ioc_transfer spi;
+	memset(&spi, 0, sizeof(spi));
 	spi.tx_buf = (unsigned long) tx_buf;
 	spi.rx_buf = (unsigned long) rx_buf;
 	spi.len = sizeof(tx_buf);
@@ -157,6 +158,7 @@ mcp23s17_read_reg(PrivateData *p, unsigned char reg)
 	unsigned char rx_buf[3] = { 0, 0, 0 };
 
 	struct spi_ioc_transfer spi;
+	memset(&spi, 0, sizeof(spi));
 	spi.tx_buf = (unsigned long) tx_buf;
 	spi.rx_buf = (unsigned long) rx_buf;
 	spi.len = sizeof(tx_buf);


### PR DESCRIPTION
Current kernels have more fields in spi_ioc_transfer than the ones that are
explicitly set by the mcp23s17_read_reg() and mcp23s17_write_reg() functions.
When some of the structure fields are not initialized, calls to ioctl() may
return EINVAL and SPI transactions will not be executed.

Clearing the structure before filling any field is an effective way of
initializing the structure, while ensuring compatibility with a wide range of
kernel versions.