### PR TITLE
IOWarrior: gcc warn if no parenthesis

### DIFF
--- a/server/drivers/IOWarrior.c
+++ b/server/drivers/IOWarrior.c
@@ -215,7 +215,7 @@ static int iowled_on_off(PrivateData *p, unsigned int pattern)
   pattern ^= 0xFFFFFFFFU;	/* invert pattern */
 
   /* map pattern to bytes */
-  for (i = 0; i < (p->productID == iowProd40) ? 4 : 2; i++) {
+  for (i = 0; i < ((p->productID == iowProd40) ? 4 : 2); i++) {
     led_cmd[i] = (unsigned char) (0xFF & pattern);
     pattern >>= 8;
   }


### PR DESCRIPTION
I don't have IOWarrior myself, but GCC generate warning on this.