### PR TITLE
Fix compilation with GCC >= 10.x

### DIFF
--- a/clients/lcdproc/iface.c
+++ b/clients/lcdproc/iface.c
@@ -32,6 +32,7 @@
 #define UNSET_INT -1
 #define UNSET_STR "\01"
 
+IfaceInfo iface[MAX_INTERFACES];        /* interface info */
 
 static int iface_count = 0;	/* number of interfaces */
 static char unit_label[10] = "B";	/* default unit label is Bytes */

--- a/clients/lcdproc/iface.h
+++ b/clients/lcdproc/iface.h
@@ -18,8 +18,6 @@
 /** max number of interfaces in multi-interface mode */
 #define MAX_INTERFACES 3
 
-IfaceInfo iface[MAX_INTERFACES];	/* interface info */
-
 /** Update screen content */
 int iface_screen(int rep, int display, int *flags_ptr);
 /** read interface stats from /proc/net/dev */

--- a/clients/lcdproc/main.c
+++ b/clients/lcdproc/main.c
@@ -53,6 +53,8 @@
 # include "eyebox.h"
 #endif
 
+extern IfaceInfo iface[MAX_INTERFACES];        /* interface info */
+
 /* The following 8 variables are defined 'external' in main.h! */
 int Quit = 0;
 int sock = -1;


### PR DESCRIPTION
Starting with GCC >= 10.x, -fno-common is used as default
instead of -fcommon. This patch fixes the compilation.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>