### PR TITLE
Fix broken behavior of checkbox/ring widgets in wizard menus

### DIFF
--- a/docs/lcdproc-user/configuration.docbook
+++ b/docs/lcdproc-user/configuration.docbook
@@ -684,14 +684,18 @@ You can configure what keys the menu should use.
 </variablelist>
 
 <para>
-The minimal keys required for the menu work correctly are the <command>MenuKey</command>,
-the <command>EnterKey</command> and one of <command>UpKey</command> or
-<command>DownKey</command>.
-With these 3 keys the menus can be operated.
+The minimal keys required for most menus to work correctly are the
+<command>MenuKey</command>, the <command>EnterKey</command> and one of
+<command>UpKey</command> or <command>DownKey</command>.
+With these 3 keys the menus can usually be operated.
 Of course with only 3 keys the navigation gets a bit awkward.
 So if you have 4 or more keys, you better use them.
 Especially the <command>LeftKey</command> and <command>RightKey</command>
 make a big difference in user experience.
+Menus using checkbox or ring widgets within configuration wizards additionally
+need one of <command>LeftKey</command> or <command>RightKey</command> to work
+correctly, because <command>EnterKey</command> is used to jump to the next
+option then.
 </para>
 
 

--- a/server/menu.c
+++ b/server/menu.c
@@ -676,19 +676,23 @@ MenuResult menu_process_input(Menu *menu, MenuToken token, const char *key, unsi
 			return menuitem_successor2menuresult(
 				subitem->successor_id, MENURESULT_NONE);
 		  case MENUITEM_CHECKBOX:
-			subitem->data.checkbox.value++;
-			subitem->data.checkbox.value %= (subitem->data.checkbox.allow_gray) ? 3 : 2;
+			if (subitem->successor_id == NULL) {
+				subitem->data.checkbox.value++;
+				subitem->data.checkbox.value %= (subitem->data.checkbox.allow_gray) ? 3 : 2;
 
-			if (subitem->event_func)
-				subitem->event_func(subitem, MENUEVENT_UPDATE);
+				if (subitem->event_func)
+					subitem->event_func(subitem, MENUEVENT_UPDATE);
+			}
 			return menuitem_successor2menuresult(
 				subitem->successor_id, MENURESULT_NONE);
 		  case MENUITEM_RING:
-			subitem->data.ring.value++;
-			subitem->data.ring.value %= LL_Length(subitem->data.ring.strings);
+			if (subitem->successor_id == NULL) {
+				subitem->data.ring.value++;
+				subitem->data.ring.value %= LL_Length(subitem->data.ring.strings);
 
-			if (subitem->event_func)
-				subitem->event_func(subitem, MENUEVENT_UPDATE);
+				if (subitem->event_func)
+					subitem->event_func(subitem, MENUEVENT_UPDATE);
+			}
 			return menuitem_successor2menuresult(
 				subitem->successor_id, MENURESULT_NONE);
 		  case MENUITEM_MENU:


### PR DESCRIPTION
If a checkbox or ring widget has a successor item set (-next), pressing
the ENTER key should not change its value.

Closes: #156