### PR TITLE
Added "BCM2711" of Raspberry Pi 400 and his changed gpio_base_address in a if...else Ladder.

### DIFF
--- a/server/drivers/hd44780-rpi.c
+++ b/server/drivers/hd44780-rpi.c
@@ -166,6 +166,7 @@ check_board_rev(Driver *drvthis)
 	/* On boards that have been overvolted, the MSB will be set */
 	if ((strcmp(hw, "BCM2708") != 0 &&
 	     strcmp(hw, "BCM2709") != 0 &&
+	     strcmp(hw, "BCM2711") != 0 &&
 	     strcmp(hw, "BCM2835") != 0) ||
 	    rev & 0xFFFFFF == 0) {
 		report(RPT_ERR, "check_board_rev: This board is not recognized as a Raspberry Pi!");
@@ -181,6 +182,11 @@ check_board_rev(Driver *drvthis)
 			/* older boards: A, B, A+, B+, ALPHA, CM */
 			report(RPT_INFO, "check_board_rev: Revision 2 board detected");
 			gpio_base_address = BCM2835_PERI_BASE_OLD + GPIO_BASE_OFFSET;
+		}
+		else if (bType == 19) {
+			/* Raspberry Pi 400 */
+			report(RPT_INFO, "check_board_rev: Raspberry Pi 400 detected ");
+			gpio_base_address = BCM2711_PERI_BASE + GPIO_BASE_OFFSET;
 		}
 		else {
 			/* modern boards: Pi2 B, Pi3 B */

--- a/server/drivers/hd44780-rpi.h
+++ b/server/drivers/hd44780-rpi.h
@@ -22,6 +22,7 @@ struct rpi_gpio_map {
 /** Peripheral base address of the BCM2835 */
 #define BCM2835_PERI_BASE_OLD        0x20000000
 #define BCM2835_PERI_BASE_NEW        0x3F000000
+#define BCM2711_PERI_BASE            0xFE000000
 /** GPIO register start address offset from PERI_BASE */
 #define GPIO_BASE_OFFSET               0x200000
 /** Length of register space */


### PR DESCRIPTION
Greetings, I'm a big Fan of LCDproc, but realized it does not work on the new Raspberry Pi 400, so I looked into it and found the new Typename, Revision and the changed GPIO Base Adress.

I hope it's OK to use the absolute value of 19 for the Revision, but I did not found a range.

Thank you for maintaining this and all the best :-)