### PR TITLE
Update Code of Merit URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ will need to have JavaScript enabled in your browser.
 ## Code of Merit
 
 This project adopts the Code of Merit, version 1.0, originally published at
-http://code-of-merit.org/. Refer to [CODE_OF_MERIT.md](CODE_OF_MERIT.md) for
+[codeofmerit.org](https://codeofmerit.org/). Refer to [CODE_OF_MERIT.md](CODE_OF_MERIT.md) for
 details, but in short, we focus on writing software and leave politics out of
 it.
 


### PR DESCRIPTION
The old http://code-of-merit.org page now redirects to https://www.mayan-edms.com/

From the new website:

>This website is independent and maintained by Valentino Giudice.
>
> The Code of Merit used to be mantained by its original author but he discontinued every one of his projects except for Mayan EDMS. This website is an attempt to keep the Code of Merit available.