### PR TITLE
lcdexec: fix bug that prevented command with arg

### DIFF
--- a/clients/lcdexec/lcdexec.c
+++ b/clients/lcdexec/lcdexec.c
@@ -418,10 +418,10 @@ static int process_response(char *str)
 			 * - command entry without args
 			 * - last arg of a command entry with args */
 			if (((entry->type == MT_EXEC) && (entry->children == NULL)) ||
-			    ((entry->type & MT_ARGUMENT) && (entry->next == NULL))) {
+			    ((entry->type == MT_AUTOMATIC) && (entry->next == NULL))) {
 
 				// last arg => get parent entry
-				if ((entry->type & MT_ARGUMENT) && (entry->next == NULL))
+				if (entry->type == MT_AUTOMATIC)
 					entry = entry->parent;
 
 				if (entry->type == MT_EXEC)

--- a/clients/lcdexec/menu.c
+++ b/clients/lcdexec/menu.c
@@ -234,7 +234,7 @@ MenuEntry *menu_read(MenuEntry *parent, const char *name)
 			me->next = NULL;
 			me->children = NULL;
 			me->numChildren = 0;
-			me->type = MT_ARG_ACTION | MT_AUTOMATIC;
+			me->type = MT_AUTOMATIC;
 
 			return me;
 		}
@@ -402,7 +402,6 @@ int menu_sock_send(MenuEntry *me, MenuEntry *parent, int sock)
 
 				break;
 			case MT_AUTOMATIC:
-			case MT_ARG_ACTION:
 				if (sock_printf(sock, "menu_add_item \"%s\" \"%d\" action \"%s\"\n",
 						parent_id, me->id, me->displayname) < 0)
 					return -1;

--- a/clients/lcdexec/menu.c
+++ b/clients/lcdexec/menu.c
@@ -234,7 +234,7 @@ MenuEntry *menu_read(MenuEntry *parent, const char *name)
 			me->next = NULL;
 			me->children = NULL;
 			me->numChildren = 0;
-			me->type = MT_ACTION;
+			me->type = MT_ARG_ACTION | MT_AUTOMATIC;
 
 			return me;
 		}
@@ -401,7 +401,8 @@ int menu_sock_send(MenuEntry *me, MenuEntry *parent, int sock)
 					return -1;
 
 				break;
-			case MT_ACTION:
+			case MT_AUTOMATIC:
+			case MT_ARG_ACTION:
 				if (sock_printf(sock, "menu_add_item \"%s\" \"%d\" action \"%s\"\n",
 						parent_id, me->id, me->displayname) < 0)
 					return -1;
@@ -538,7 +539,7 @@ void menu_dump(MenuEntry *me)
 {
 	if (me != NULL) {
 		/* the quick way out */
-		if (me->type & MT_ACTION)
+		if (me->type & MT_AUTOMATIC)
 			return;
 
 		report(RPT_DEBUG, "# menu ID: %d", me->id);

--- a/clients/lcdexec/menu.h
+++ b/clients/lcdexec/menu.h
@@ -29,7 +29,7 @@ typedef enum {
 	MT_MENU         = 0x10,	/**< MenuEntry representing a menu. */
 	MT_EXEC         = 0x20,	/**< MenuEntry representing an executable command. */
 	MT_ARGUMENT     = 0x40,	/**< Mask denoting a parameter of any type */
-	MT_ACTION	= 0x80,	/**< Automatically generated action menu */
+	MT_AUTOMATIC	= 0x80,	/**< BitFlag denoting automatically generated entries */
 
 	MT_ARG_SLIDER   = 0x41,	/**< MenuEntry representing a slider parameter. */
 	MT_ARG_RING     = 0x42,	/**< MenuEntry representing a ring parameter. */
@@ -37,6 +37,7 @@ typedef enum {
 	MT_ARG_ALPHA    = 0x44,	/**< MenuEntry representing a alpha input parameter. */
 	MT_ARG_IP       = 0x45,	/**< MenuEntry representing a IP input parameter. */
 	MT_ARG_CHECKBOX = 0x46,	/**< MenuEntry representing a checkbox input parameter. */
+	MT_ARG_ACTION   = 0x47,	/**< MenuEntry representing a checkbox input parameter. */
 } MenuType;	
 
 

--- a/clients/lcdexec/menu.h
+++ b/clients/lcdexec/menu.h
@@ -28,7 +28,6 @@ typedef enum {
 	MT_UNKNOWN      = 0x00,	/**< Unknown MenuEntry type. */
 	MT_MENU         = 0x10,	/**< MenuEntry representing a menu. */
 	MT_EXEC         = 0x20,	/**< MenuEntry representing an executable command. */
-	MT_ARGUMENT     = 0x40,	/**< Mask denoting a parameter of any type */
 	MT_AUTOMATIC	= 0x80,	/**< BitFlag denoting automatically generated entries */
 
 	MT_ARG_SLIDER   = 0x41,	/**< MenuEntry representing a slider parameter. */
@@ -37,8 +36,7 @@ typedef enum {
 	MT_ARG_ALPHA    = 0x44,	/**< MenuEntry representing a alpha input parameter. */
 	MT_ARG_IP       = 0x45,	/**< MenuEntry representing a IP input parameter. */
 	MT_ARG_CHECKBOX = 0x46,	/**< MenuEntry representing a checkbox input parameter. */
-	MT_ARG_ACTION   = 0x47,	/**< MenuEntry representing a checkbox input parameter. */
-} MenuType;	
+} MenuType;
 
 
 /** Data structure to hold a menu entry in \c lcdexec */


### PR DESCRIPTION
It looks like this bug slipped through the cracks with commit c39c4f14



