### PR TITLE
Add Disk ignore list, fix buffer overflow.

### DIFF
--- a/clients/lcdproc/lcdproc.conf
+++ b/clients/lcdproc/lcdproc.conf
@@ -140,7 +140,14 @@ Active=false
 [Disk]
 # Show screen
 Active=false
-
+# You can add up to 10 "Ignore" entries to have lcdproc ignore
+# mounts that are not of interest. By default it attempts to filter
+# filesystem types like procfs but of course this doesn't prevent 
+# entries you wish to have mounted but don't need to monitor 
+# (like /boot/efi) from being listed. 
+Ignore=/boot/efi
+Ignore=/dev
+#Ignore=...
 
 [MiniClock]
 # Show screen


### PR DESCRIPTION
- Fix the buffer overflow for wide displays with long mount paths.
  -  Closes #178 
  -  Supersedes #158 
- Add an "ignore" list feature to the lcdproc config file for non-interesting mount points. 
  - Closes #179

Up to 10 mountpoints can be ignored, but this limit can be adjusted by changing the appropriate #define and recompiling.
