### PR TITLE
hd44780/ethlcd: introduce a retransmission code

### DIFF
--- a/server/drivers/hd44780-ethlcd.h
+++ b/server/drivers/hd44780-ethlcd.h
@@ -6,7 +6,8 @@ int hd_init_ethlcd(Driver *drvthis);
 
 #define ETHLCD_DRV_NAME      "ethlcd"
 #define DEFAULT_ETHLCD_PORT  2425
-#define ETHLCD_TIMEOUT       5
+#define ETHLCD_TIMEOUT       1
+#define ETHLCD_MAX_RETRIES   3
 
 /* ethlcd protocol constants: */
 #define ETHLCD_SEND_INSTR               0x01


### PR DESCRIPTION
This commit adds support for better communication handling
with ethlcd device. Previously when a single problem occured,
the LCDd was exiting. Now it is trying three times before
giving up.

The 5-seconds timeout value was adjusted to 1 sec because
after this delay a retransmission is occuring.
Now it can easily recover from single transmission errors
without dropping client connections.

Signed-off-by: Mariusz Bialonczyk <manio@skyboo.net>

---
ps. I am really glad, that we're now on github - my first ethlcd commits was created locally (on top on CVS sources) and send to ML :)