### PR TITLE
drivers/g15: Always depend on freetype2

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -164,21 +164,25 @@ dnl				else
 dnl			else
 				AC_MSG_WARN([libg15daemon_client.h not found, the g15 driver will lack g15daemon support])
 			])
-			AC_CHECK_HEADERS([libg15render.h],[
-				AC_CHECK_LIB(g15render, g15r_initCanvas,[
-					LIBG15="$LIBG15 -lg15render"
-					DRIVERS="$DRIVERS g15${SO}"
-					actdrivers=["$actdrivers g15"]
+			if test "$enable_freetype" = "yes"; then
+				AC_CHECK_HEADERS([libg15render.h],[
+					AC_CHECK_LIB(g15render, g15r_initCanvas,[
+						LIBG15="$LIBG15 -lg15render"
+						DRIVERS="$DRIVERS g15${SO}"
+						actdrivers=["$actdrivers g15"]
+					],[
+dnl					else
+						AC_MSG_WARN([the g15 driver needs libg15render])
+					],
+					[-lg15render]
+					)
 				],[
 dnl				else
-					AC_MSG_WARN([the g15 driver needs libg15render])
-				],
-				[-lg15render]
-				)
-			],[
-dnl			else
-				AC_MSG_WARN([The g15driver needs libg15render.h])
-			])
+					AC_MSG_WARN([The g15driver needs libg15render.h])
+				])
+			else
+				AC_MSG_WARN([libg15render ist broken without freetype])
+			fi
 			;;
 		glcd)
 			GLCD_DRIVERS=""

--- a/server/drivers/g15.c
+++ b/server/drivers/g15.c
@@ -51,16 +51,14 @@ static inline int g15_send(int sock, char *buf, unsigned int len) { return -1; }
 #endif
 
 /*
- * If we have freetype2, assume libg15render is build with TTF support,
+ * Workaround for upstream bug: Assume libg15render is build with TTF support,
  * the TTF_SUPPORT define makes the size of the g15 struct bigger, if we do
  * not set this define while libg15render is build with TTF support we get
  * heap corruption. The other way around does not matter, then we just alloc
  * a little bit too much memory (the TTF related variables live at the end
  * of the struct).
  */
-#ifdef HAVE_FT2
 #define TTF_SUPPORT
-#endif
 #include <libg15render.h>
 
 #include "lcd.h"


### PR DESCRIPTION
This is a workaround for an upstream bug. For details see the following
issue. (Closes: #188)

Signed-off-by: Harald Geyer <harald@ccbib.org>