### PR TITLE
Add DisableBuffer option for LCD2USB driver

### DIFF
--- a/server/drivers/hd44780-lcd2usb.h
+++ b/server/drivers/hd44780-lcd2usb.h
@@ -33,6 +33,11 @@
 #define LCD2USB_GET_CTRL	(LCD2USB_GET | (2<<3))
 #define LCD2USB_GET_RESERVED1	(LCD2USB_GET | (3<<3))
 
+/** private data for the \c lcd2usb driver */
+typedef struct LCD2USB_private_data {
+	char disablebuffer;
+} LCD2USBPrivateData;
+
 // initialise this particular driver
 int hd_init_lcd2usb(Driver *drvthis);
 

--- a/server/drivers/hd44780-low.h
+++ b/server/drivers/hd44780-low.h
@@ -363,6 +363,9 @@ typedef struct hd44780_private_data {
 
 	/** Output buffer to collect command or data bytes */
 	tx_buffer tx_buf;
+
+	/* Sub private data specific to connection type */
+	void *connectionprivatedata;
 } PrivateData;
 
 


### PR DESCRIPTION
This is a workaround for #192. It adds a boolean option `DisableBuffer` to `hd44780-lcd2usb` that ignores the `tx_buf` of LCD2USB as a workaround for Chinese counterfeit LCD2USB modules.

This is only a rough implementation that tested working on my device. I am not sure if this is up to the code of contribution but I mostly copied the existing source. 
