### PR TITLE
Support seamless HBAR in CFA-635

### DIFF
--- a/server/drivers/CFontzPacket.c
+++ b/server/drivers/CFontzPacket.c
@@ -96,7 +96,7 @@ static CFA_Model CFA_ModelList[] = {
 	{631, "20x2", 5, 115200, CFontz_charmap , CFA_HAS_FAN | CFA_HAS_TEMP |
 						CFA_HAS_KS0073 | CFA_HAS_4_TEMP_SLOTS},
 	{633, "16x2", 5, 19200 , HD44780_charmap, CFA_HAS_FAN | CFA_HAS_TEMP},
-	{635, "20x4", 5, 115200, CFontz_charmap , CFA_HAS_KS0073},
+	{635, "20x4", 6, 115200, CFontz_charmap , CFA_HAS_KS0073 | CFA_IS_SEAMLESS},
 	{0, NULL, 0, 0, NULL, 0}
 };
 
@@ -861,7 +861,9 @@ CFontzPacket_hbar (Driver *drvthis, int x, int y, int len, int promille, int opt
 			CFontzPacket_set_char(drvthis, i, hBar);
 		}
 	}
-
+	if (p->model_desc->flags & CFA_IS_SEAMLESS) {
+		options |= BAR_SEAMLESS;
+	}
 	lib_hbar_static(drvthis, x, y, len, promille, options, p->cellwidth, 0);
 }
 

--- a/server/drivers/CFontzPacket.h
+++ b/server/drivers/CFontzPacket.h
@@ -11,6 +11,7 @@
 #define CFA_HAS_TEMP		0x0002
 #define CFA_HAS_4_TEMP_SLOTS	0x0004
 #define CFA_HAS_KS0073		0x0008
+#define CFA_IS_SEAMLESS		0x0010
 
 /** Structure describing features of a known display model */
 typedef struct CFA_Model {


### PR DESCRIPTION
The CFA-635 USB display supports seamless characters via 6x8 cells, much like some of the `CFontz` driver displays.

This patch implements support for seamless horizontal bars for this model by setting the appropriate option on `lib_hbar_static` and in the model data for `CFontzPacket.c`

Appearance example/demo/test (MythTV video Playback):

![image](https://github.com/lcdproc/lcdproc/assets/53943260/5b8a32d4-d601-4748-864e-44a3147946e4)
