### PR TITLE
Add support for linux /dev/lcd character device

### DIFF
--- a/LCDd.conf
+++ b/LCDd.conf
@@ -907,6 +907,13 @@ Device=/dev/ttyS1
 Size=16x2
 
 
+## Linux /dev/lcd kernel driver ##
+[linux_devlcd]
+# Set the display size [default: 20x4]
+Size=16x2
+Device=/dev/lcd
+
+
 ## Linux event device input driver ##
 [linux_input]
 

--- a/LCDd.conf
+++ b/LCDd.conf
@@ -911,6 +911,7 @@ Size=16x2
 [linux_devlcd]
 # Set the display size [default: 20x4]
 Size=16x2
+# device to use [default: /dev/lcd]
 Device=/dev/lcd
 
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -11,7 +11,8 @@ AC_ARG_ENABLE(drivers,
 	[                    bayrad,CFontz,CFontzPacket,curses,CwLnx,ea65,]
 	[                    EyeboxOne,futaba,g15,glcd,glcdlib,glk,hd44780,i2500vfd,]
 	[                    icp_a106,imon,imonlcd,IOWarrior,irman,irtrans,]
-	[                    joy,jw002,lb216,lcdm001,lcterm,linux_input,lirc,lis,MD8800,mdm166a,]
+	[                    joy,jw002,lb216,lcdm001,lcterm,linux_devlcd,]
+	[                    linux_input,lirc,lis,MD8800,mdm166a,]
 	[                    ms6931,mtc_s16209x,MtxOrb,mx5000,NoritakeVFD,]
 	[                    Olimex_MOD_LCD1x9,picolcd,pyramid,rawserial,]
 	[                    sdeclcd,sed1330,sed1520,serialPOS,serialVFD,]
@@ -23,7 +24,7 @@ AC_ARG_ENABLE(drivers,
 	drivers="$enableval",
 	drivers=[bayrad,CFontz,CFontzPacket,curses,CwLnx,glk,lb216,lcdm001,MtxOrb,pyramid,text])
 
-allDrivers=[bayrad,CFontz,CFontzPacket,curses,CwLnx,ea65,EyeboxOne,futaba,g15,glcd,glcdlib,glk,hd44780,i2500vfd,icp_a106,imon,imonlcd,IOWarrior,irman,irtrans,joy,jw002,lb216,lcdm001,lcterm,linux_input,lirc,lis,MD8800,mdm166a,ms6931,mtc_s16209x,MtxOrb,mx5000,NoritakeVFD,Olimex_MOD_LCD1x9,picolcd,pyramid,sdeclcd,sed1330,sed1520,serialPOS,serialVFD,shuttleVFD,sli,stv5730,SureElec,svga,t6963,text,tyan,ula200,vlsys_m428,xosd,rawserial,yard2LCD]
+allDrivers=[bayrad,CFontz,CFontzPacket,curses,CwLnx,ea65,EyeboxOne,futaba,g15,glcd,glcdlib,glk,hd44780,i2500vfd,icp_a106,imon,imonlcd,IOWarrior,irman,irtrans,joy,jw002,lb216,lcdm001,lcterm,linux_devlcd,linux_input,lirc,lis,MD8800,mdm166a,ms6931,mtc_s16209x,MtxOrb,mx5000,NoritakeVFD,Olimex_MOD_LCD1x9,picolcd,pyramid,sdeclcd,sed1330,sed1520,serialPOS,serialVFD,shuttleVFD,sli,stv5730,SureElec,svga,t6963,text,tyan,ula200,vlsys_m428,xosd,rawserial,yard2LCD]
 if test "$debug" = yes; then
 	allDrivers=["${allDrivers},debug"]
 fi
@@ -358,6 +359,14 @@ dnl				else
 			*-*-linux*)
 				DRIVERS="$DRIVERS linux_input${SO}"
 				actdrivers=["$actdrivers linux_input"]
+				;;
+			esac
+			;;
+		linux_devlcd)
+			case $host in
+			*-*-linux*)
+				DRIVERS="$DRIVERS linux_devlcd${SO}"
+				actdrivers=["$actdrivers linux_devlcd"]
 				;;
 			esac
 			;;

--- a/docs/lcdproc-user/drivers/Makefile.am
+++ b/docs/lcdproc-user/drivers/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST =	bayrad.docbook \
 		lb216.docbook \
 		lcdm001.docbook \
 		lcterm.docbook \
+		linux_devlcd.docbook \
 		linux_input.docbook \
 		lircin.docbook \
 		lis.docbook \

--- a/docs/lcdproc-user/drivers/linux_devlcd.docbook
+++ b/docs/lcdproc-user/drivers/linux_devlcd.docbook
@@ -1,0 +1,42 @@
+<sect1 id="linux_devlcd-howto">
+<title>The linux_devlcd Driver</title>
+
+<para>
+The linux_devlcd driver outputs the content of the internal framebuffer to
+the the linux kernel /dev/lcd character device.
+</para>
+
+<!-- ## Text driver ## -->
+<sect2 id="linux_devlcd-config">
+<title>Configuration in LCDd.conf</title>
+
+<sect3 id="linux_devlcd-config-section">
+<title>[linux_devlcd]</title>
+
+<variablelist>
+<varlistentry>
+  <term>
+    <property>Size</property> = &parameters.size;
+  </term>
+  <listitem><para>
+    Set the display size [default: <literal>20x4</literal>]
+  </para></listitem>
+</varlistentry>
+
+<varlistentry>
+  <term>
+    <property>Device</property> =
+    <parameter><replaceable>DEVICE</replaceable></parameter>
+  </term>
+  <listitem><para>
+  Linux kernel device to use. Default: <filename>/dev/lcd</filename>
+  </para></listitem>
+</varlistentry>
+
+</variablelist>
+
+</sect3>
+
+</sect2>
+
+</sect1>

--- a/server/drivers/Makefile.am
+++ b/server/drivers/Makefile.am
@@ -23,7 +23,7 @@ AM_LDFLAGS = @LDSHARED@
 
 lcdexecbindir = $(pkglibdir)
 lcdexecbin_PROGRAMS = @DRIVERS@
-EXTRA_PROGRAMS = bayrad CFontz CFontzPacket curses CwLnx debug ea65 EyeboxOne futaba g15 glcd glcdlib glk hd44780 i2500vfd icp_a106 imon imonlcd IOWarrior irman irtrans joy jw002 lb216 lcdm001 lcterm linux_input lirc lis MD8800 mdm166a ms6931 mtc_s16209x MtxOrb mx5000 NoritakeVFD Olimex_MOD_LCD1x9 picolcd pyramid rawserial sdeclcd sed1330 sed1520 serialPOS serialVFD shuttleVFD sli stv5730 SureElec svga t6963 text tyan ula200 vlsys_m428 xosd yard2LCD
+EXTRA_PROGRAMS = bayrad CFontz CFontzPacket curses CwLnx debug ea65 EyeboxOne futaba g15 glcd glcdlib glk hd44780 i2500vfd icp_a106 imon imonlcd IOWarrior irman irtrans joy jw002 lb216 lcdm001 lcterm linux_devlcd linux_input lirc lis MD8800 mdm166a ms6931 mtc_s16209x MtxOrb mx5000 NoritakeVFD Olimex_MOD_LCD1x9 picolcd pyramid rawserial sdeclcd sed1330 sed1520 serialPOS serialVFD shuttleVFD sli stv5730 SureElec svga t6963 text tyan ula200 vlsys_m428 xosd yard2LCD
 noinst_LIBRARIES = libLCD.a libbignum.a
 
 futaba_CFLAGS =      @LIBUSB_CFLAGS@ @LIBUSB_1_0_CFLAGS@ $(AM_CFLAGS)
@@ -112,6 +112,7 @@ jw002_SOURCES =      lcd.h lcd_lib.h jw002.c jw002.h adv_bignum.h
 lb216_SOURCES =      lcd.h lcd_lib.h lb216.c lb216.h
 lcdm001_SOURCES =    lcd.h lcdm001.c lcdm001.h
 lcterm_SOURCES =     lcd.h lcd_lib.h lcterm.c lcterm.h
+linux_devlcd_SOURCES = lcd.h linux_devlcd.h linux_devlcd.c
 linux_input_SOURCES = lcd.h linux_input.h linux_input.c
 lirc_SOURCES =       lcd.h lircin.c lircin.h
 lis_SOURCES =        lcd.h lcd_lib.h lis.h lis.c

--- a/server/drivers/linux_devlcd.c
+++ b/server/drivers/linux_devlcd.c
@@ -1,0 +1,312 @@
+/** \file server/drivers/linux_devlcd.c
+ * LCDd \c driver for linux kernel /dev/lcd device
+ * It displays the LCD screens, one below the other on the terminal,
+ */
+
+/* Copyright (C) 2024 The LCDproc Team
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include "lcd.h"
+#include "linux_devlcd.h"
+#include "shared/report.h"
+
+
+/** private data for the \c text driver */
+typedef struct linuxDevLcd_private_data {
+	int width;		/**< display width in characters */
+	int height;		/**< display height in characters */
+	char *framebuf;		/**< fram buffer */
+	FILE* fd;		/**< handle to the device */
+} PrivateData;
+
+
+/* Vars for the server core */
+MODULE_EXPORT char *api_version = API_VERSION;
+MODULE_EXPORT int stay_in_foreground = 0;
+MODULE_EXPORT int supports_multiple = 0;
+MODULE_EXPORT char *symbol_prefix = "linuxDevLcd_";
+
+
+/**
+ * Initialize the driver.
+ * \param drvthis  Pointer to driver structure.
+ * \retval 0       Success.
+ * \retval <0      Error.
+ */
+MODULE_EXPORT int
+linuxDevLcd_init (Driver *drvthis)
+{
+	PrivateData *p;
+	char buf[256];
+	char device[200];
+
+	/* Allocate and store private data */
+	p = (PrivateData *) calloc(1, sizeof(PrivateData));
+	if (p == NULL)
+		return -1;
+	if (drvthis->store_private_ptr(drvthis, p))
+		return -1;
+
+	/* initialize private data */
+
+	/* which device should be used */
+	strncpy(device, drvthis->config_get_string(drvthis->name, "Device", 0, DEFAULT_DEVICE),
+		sizeof(device));
+	device[sizeof(device) - 1] = '\0';
+
+	report(RPT_INFO, "%s: using Device %s",
+	       drvthis->name, device);
+
+	// Set display sizes
+	if ((drvthis->request_display_width() > 0)
+	    && (drvthis->request_display_height() > 0)) {
+		// Use size from primary driver
+		p->width = drvthis->request_display_width();
+		p->height = drvthis->request_display_height();
+	}
+	else {
+		/* Use our own size from config file */
+		strncpy(buf, drvthis->config_get_string(drvthis->name, "Size", 0, TEXTDRV_DEFAULT_SIZE), sizeof(buf));
+		buf[sizeof(buf)-1] = '\0';
+		if ((sscanf(buf , "%dx%d", &p->width, &p->height) != 2)
+		    || (p->width <= 0) || (p->width > LCD_MAX_WIDTH)
+		    || (p->height <= 0) || (p->height > LCD_MAX_HEIGHT)) {
+			report(RPT_WARNING, "%s: cannot read Size: %s; using default %s",
+					drvthis->name, buf, TEXTDRV_DEFAULT_SIZE);
+			sscanf(TEXTDRV_DEFAULT_SIZE, "%dx%d", &p->width, &p->height);
+		}
+	}
+
+	// Allocate the framebuffer
+	p->framebuf = malloc(p->width * p->height);
+	if (p->framebuf == NULL) {
+		report(RPT_ERR, "%s: unable to create framebuffer", drvthis->name);
+		return -1;
+	}
+	memset(p->framebuf, ' ', p->width * p->height);
+
+	/* open the device... */
+	if (!strcmp(device,"-")) {
+		p->fd = stdout;
+	} else {
+		p->fd = fopen(device, "w" );
+	}
+	if (p->fd == 0) {
+		report(RPT_ERR, "%s: open(%s) failed (%s)", drvthis->name, device, strerror(errno));
+		if (errno == EACCES)
+			report(RPT_ERR, "%s: device %s could not be opened", drvthis->name, device);
+		goto err_out;
+	}
+	report(RPT_INFO, "%s: opened display on %s", drvthis->name, device);
+
+	fprintf(p->fd, "\e[LI"); // Reinitialise display
+
+	report(RPT_DEBUG, "%s: init() done", drvthis->name);
+
+	return 0;
+
+      err_out:
+	linuxDevLcd_close(drvthis);
+	return -1;
+}
+
+
+/**
+ * Close the driver (do necessary clean-up).
+ * \param drvthis  Pointer to driver structure.
+ */
+MODULE_EXPORT void
+linuxDevLcd_close (Driver *drvthis)
+{
+	PrivateData *p = drvthis->private_data;
+
+	if (p != NULL) {
+		if (p->framebuf != NULL)
+			free(p->framebuf);
+
+		free(p);
+	}
+	drvthis->store_private_ptr(drvthis, NULL);
+}
+
+
+/**
+ * Return the display width in characters.
+ * \param drvthis  Pointer to driver structure.
+ * \return         Number of characters the display is wide.
+ */
+MODULE_EXPORT int
+linuxDevLcd_width (Driver *drvthis)
+{
+	PrivateData *p = drvthis->private_data;
+
+	return p->width;
+}
+
+
+/**
+ * Return the display height in characters.
+ * \param drvthis  Pointer to driver structure.
+ * \return         Number of characters the display is high.
+ */
+MODULE_EXPORT int
+linuxDevLcd_height (Driver *drvthis)
+{
+	PrivateData *p = drvthis->private_data;
+
+	return p->height;
+}
+
+
+/**
+ * Clear the screen.
+ * \param drvthis  Pointer to driver structure.
+ */
+MODULE_EXPORT void
+linuxDevLcd_clear (Driver *drvthis)
+{
+	PrivateData *p = drvthis->private_data;
+
+	memset(p->framebuf, ' ', p->width * p->height);
+}
+
+
+/**
+ * Flush data on screen to the display.
+ * \param drvthis  Pointer to driver structure.
+ */
+MODULE_EXPORT void
+linuxDevLcd_flush (Driver *drvthis)
+{
+	PrivateData *p = drvthis->private_data;
+	char out[LCD_MAX_WIDTH];
+	int i;
+
+	fprintf(p->fd, "\e[H"); // cursor home
+	for (i = 0; i < p->height; i++) {
+		memcpy(out, p->framebuf + (i * p->width), p->width);
+		out[p->width] = '\0';
+		fprintf(p->fd, "%s\n", out);
+	}
+
+        fflush(p->fd);
+}
+
+
+/**
+ * Print a string on the screen at position (x,y).
+ * The upper-left corner is (1,1), the lower-right corner is (p->width, p->height).
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param y        Vertical character position (row).
+ * \param string   String that gets written.
+ */
+MODULE_EXPORT void
+linuxDevLcd_string (Driver *drvthis, int x, int y, const char string[])
+{
+	PrivateData *p = drvthis->private_data;
+	int i;
+
+	x--; y--; // Convert 1-based coords to 0-based...
+
+	if ((y < 0) || (y >= p->height))
+                return;
+
+	for (i = 0; (string[i] != '\0') && (x < p->width); i++, x++) {
+		if (x >= 0)	// no write left of left border
+			p->framebuf[(y * p->width) + x] = string[i];
+	}
+}
+
+
+/**
+ * Print a character on the screen at position (x,y).
+ * The upper-left corner is (1,1), the lower-right corner is (p->width, p->height).
+ * \param drvthis  Pointer to driver structure.
+ * \param x        Horizontal character position (column).
+ * \param y        Vertical character position (row).
+ * \param c        Character that gets written.
+ */
+MODULE_EXPORT void
+linuxDevLcd_chr (Driver *drvthis, int x, int y, char c)
+{
+	PrivateData *p = drvthis->private_data;
+
+	y--; x--;
+
+	if ((x >= 0) && (y >= 0) && (x < p->width) && (y < p->height))
+		p->framebuf[(y * p->width) + x] = c;
+}
+
+
+/**
+ * Change the display contrast.
+ * linux /dev/lcd driver does not support this, so we ignore it.
+ * \param drvthis  Pointer to driver structure.
+ * \param promille New contrast value in promille.
+ */
+MODULE_EXPORT void
+linuxDevLcd_set_contrast (Driver *drvthis, int promille)
+{
+	//PrivateData *p = drvthis->private_data;
+
+	debug(RPT_DEBUG, "Contrast: %d", promille);
+}
+
+
+/**
+ * Turn the display backlight on or off.
+ * linux /dev/lcd driver uses escape sequences to implement this
+ * \param drvthis  Pointer to driver structure.
+ * \param on       New backlight status.
+ */
+MODULE_EXPORT void
+linuxDevLcd_backlight (Driver *drvthis, int on)
+{
+	PrivateData *p = drvthis->private_data;
+
+// linux /dev/lcd driver escape codes
+//  \E[L+ Back light on
+//  \E[L- Back light off
+	fprintf(p->fd, "\e[L%c", (on) ? '+' : '-');
+	fflush(p->fd);
+}
+
+
+/**
+ * Provide some information about this driver.
+ * \param drvthis  Pointer to driver structure.
+ * \return         Constant string with information.
+ */
+MODULE_EXPORT const char *
+linuxDevLcd_get_info (Driver *drvthis)
+{
+	//PrivateData *p = drvthis->private_data;
+        static char *info_string = "Text mode driver";
+
+	return info_string;
+}

--- a/server/drivers/linux_devlcd.h
+++ b/server/drivers/linux_devlcd.h
@@ -1,0 +1,19 @@
+#ifndef LINUX_DEVLCD_H
+#define LINUX_DEVLCD_H
+
+MODULE_EXPORT int  linuxDevLcd_init (Driver *drvthis);
+MODULE_EXPORT void linuxDevLcd_close (Driver *drvthis);
+MODULE_EXPORT int  linuxDevLcd_width (Driver *drvthis);
+MODULE_EXPORT int  linuxDevLcd_height (Driver *drvthis);
+MODULE_EXPORT void linuxDevLcd_clear (Driver *drvthis);
+MODULE_EXPORT void linuxDevLcd_flush (Driver *drvthis);
+MODULE_EXPORT void linuxDevLcd_string (Driver *drvthis, int x, int y, const char string[]);
+MODULE_EXPORT void linuxDevLcd_chr (Driver *drvthis, int x, int y, char c);
+MODULE_EXPORT void linuxDevLcd_set_contrast (Driver *drvthis, int promille);
+MODULE_EXPORT void linuxDevLcd_backlight (Driver *drvthis, int on);
+MODULE_EXPORT const char * linuxDevLcd_get_info (Driver *drvthis);
+
+#define DEFAULT_DEVICE	"-"
+#define TEXTDRV_DEFAULT_SIZE "20x4"
+
+#endif

--- a/server/drivers/linux_devlcd.h
+++ b/server/drivers/linux_devlcd.h
@@ -13,7 +13,7 @@ MODULE_EXPORT void linuxDevLcd_set_contrast (Driver *drvthis, int promille);
 MODULE_EXPORT void linuxDevLcd_backlight (Driver *drvthis, int on);
 MODULE_EXPORT const char * linuxDevLcd_get_info (Driver *drvthis);
 
-#define DEFAULT_DEVICE	"-"
+#define DEFAULT_DEVICE	"/dev/lcd"
 #define TEXTDRV_DEFAULT_SIZE "20x4"
 
 #endif


### PR DESCRIPTION
    Added linux_devlcd output driver.
    This uses the mainline linux driver which supports hd44780 and maybe other devices
    Some useful resources on the kernel side:
    - https://github.com/torvalds/linux/commit/d47d88361feea2ce11f39bd70467ffc19a61d2d3
    - https://blog.microjoe.org/2019/hd44780-lcd-i2c-screen-using-linux-mainline-charlcd-driver.html
    - https://forums.raspberrypi.com/viewtopic.php?t=285415
