### PR TITLE
12 hour mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ This is a version that modifies the lcdproc/clients/lcdproc/chrono.c file
 so that the Big Number widget will display in 12 Hour format instead of the
 default 24 Hour format.
 
+Now has the option to set 12/24 hour format in lcdproc.conf!
+
 I have a pretty specific use case for this, but if you find it useful, then
 awesome!
+
+Also, please be aware that I am not a master C dev, so expect bugs.
 
 --------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-[![Build Status](https://travis-ci.org/lcdproc/lcdproc.svg?branch=master)](https://travis-ci.org/lcdproc/lcdproc)
 
-This is the official repository for the LCDproc project.
+# This is NOT the official repository for the LCDproc project.
+You can find the official project [here.](https://github.com/lcdproc/lcdproc)
 
-_Note: this project is currently being migrated from Sourceforge. Documentation
-is still being updated to reflect this and we're still getting our bearings here
-on GitHub, so please excuse the dust while we set up shop._
+This is a version that modifies the lcdproc/clients/lcdproc/chrono.c file
+so that the Big Number widget will display in 12 Hour format instead of the
+default 24 Hour format.
+
+I have a pretty specific use case for this, but if you find it useful, then
+awesome!
+
+--------------------------------------------------------------------------------
 
 # Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # This is NOT the official repository for the LCDproc project.
 You can find the official project [here.](https://github.com/lcdproc/lcdproc)
 
-This is a version that modifies the lcdproc/clients/lcdproc/chrono.c file
+This is a version that modifies the clients/lcdproc/chrono.c file
 so that the Big Number widget will display in 12 Hour format instead of the
 default 24 Hour format.
 

--- a/clients/lcdproc/chrono.c
+++ b/clients/lcdproc/chrono.c
@@ -400,7 +400,7 @@ big_clock_screen(int rep, int display, int *flags_ptr)
 	char fulltxt[16];
 	static char old_fulltxt[16];
 	static int heartbeat = 0;
-	static int TwentyFourHour = 1;
+	static int TwentyFourHour = 0;
 	int j = 0;
 	int digits = (lcd_wid >= 20) ? 6 : 4;
 	int xoffs = 0;

--- a/clients/lcdproc/chrono.c
+++ b/clients/lcdproc/chrono.c
@@ -400,11 +400,20 @@ big_clock_screen(int rep, int display, int *flags_ptr)
 	char fulltxt[16];
 	static char old_fulltxt[16];
 	static int heartbeat = 0;
-	static int TwentyFourHour = 0;
 	int j = 0;
 	int digits = (lcd_wid >= 20) ? 6 : 4;
 	int xoffs = 0;
 
+	// shared/configfile.h describes the arguments for config_get_bool
+	// TwentyFourHour used to be a static int, but I was tired of changing
+	// the value on every software update, so I changed it.
+	int TwentyFourHour = config_get_bool("BigClock", "TwentyFourHour", 0, 1);
+	if (!TwentyFourHour) {
+		TwentyFourHour = 0;
+	}
+
+	// I don't know why I didn't think to check this. Am I finally learning
+	// how to read and write C?? *GASP*
 	int showSecs = config_get_bool("BigClock", "showSecs", 0, 1);
 	if (!showSecs) {
 		digits = 4;

--- a/clients/lcdproc/chrono.c
+++ b/clients/lcdproc/chrono.c
@@ -404,16 +404,11 @@ big_clock_screen(int rep, int display, int *flags_ptr)
 	int digits = (lcd_wid >= 20) ? 6 : 4;
 	int xoffs = 0;
 
-	// shared/configfile.h describes the arguments for config_get_bool
-	// TwentyFourHour used to be a static int, but I was tired of changing
-	// the value on every software update, so I changed it.
 	int TwentyFourHour = config_get_bool("BigClock", "TwentyFourHour", 0, 1);
 	if (!TwentyFourHour) {
 		TwentyFourHour = 0;
 	}
 
-	// I don't know why I didn't think to check this. Am I finally learning
-	// how to read and write C?? *GASP*
 	int showSecs = config_get_bool("BigClock", "showSecs", 0, 1);
 	if (!showSecs) {
 		digits = 4;

--- a/clients/lcdproc/lcdproc.conf
+++ b/clients/lcdproc/lcdproc.conf
@@ -116,6 +116,11 @@ Active=false
 # false : the date is displayed in format HH:MM
 # [default: true; legal: true, false]
 #showSecs=true
+# Whether or not to show 12 hour time
+# true : the clock is displayed in 24 hour format (default)
+# false : the clock is displayed in 12 hour format
+# [default: false; legal: true, false]
+#TwentyFourHour=true
 
 [Uptime]
 # Show screen

--- a/clients/lcdproc/lcdproc.conf
+++ b/clients/lcdproc/lcdproc.conf
@@ -116,10 +116,10 @@ Active=false
 # false : the date is displayed in format HH:MM
 # [default: true; legal: true, false]
 #showSecs=true
-# Whether or not to show 12 hour time
+# Whether or not to show 12 or 24 hour time
 # true : the clock is displayed in 24 hour format (default)
 # false : the clock is displayed in 12 hour format
-# [default: false; legal: true, false]
+# [default: true; legal: true, false]
 #TwentyFourHour=true
 
 [Uptime]


### PR DESCRIPTION
Added an option to switch from 24 hour to 12 hour in crono.c in the lcdproc client.

I have wanted this option for years but always hand edited the files and recompiled. Now you don't have to do that.